### PR TITLE
feat : 생성·수정일 컬럼을 BaseTimeEntity로 통합해 공통 엔티티로 관리 (#45) 

### DIFF
--- a/src/main/java/com/workhub/WorkhubApplication.java
+++ b/src/main/java/com/workhub/WorkhubApplication.java
@@ -2,8 +2,10 @@ package com.workhub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class WorkhubApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/workhub/checklist/entity/CheckListComment.java
+++ b/src/main/java/com/workhub/checklist/entity/CheckListComment.java
@@ -1,22 +1,23 @@
 package com.workhub.checklist.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Builder
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "check_list_comment")
 @Entity
-public class CheckListComment {
+public class CheckListComment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,12 +33,6 @@ public class CheckListComment {
 
     @Column(name = "cl_content", columnDefinition = "TEXT")
     private String clContent;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Column(name = "check_list_item_id")
     private Long checkListItemId;

--- a/src/main/java/com/workhub/cs/entity/CsPost.java
+++ b/src/main/java/com/workhub/cs/entity/CsPost.java
@@ -1,31 +1,27 @@
 package com.workhub.cs.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "cs_post")
 @Entity
-public class CsPost {
+public class CsPost extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cs_post_id")
     private Long csPostId;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/src/main/java/com/workhub/cs/entity/CsPostFile.java
+++ b/src/main/java/com/workhub/cs/entity/CsPostFile.java
@@ -1,20 +1,19 @@
 package com.workhub.cs.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "cs_post_file")
 @Entity
-public class CsPostFile {
+public class CsPostFile extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,9 +28,6 @@ public class CsPostFile {
 
     @Column(name = "file_order")
     private Integer fileOrder;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 
     @Column(name = "cs_post_id")
     private Long csPostId;

--- a/src/main/java/com/workhub/cs/entity/CsQna.java
+++ b/src/main/java/com/workhub/cs/entity/CsQna.java
@@ -1,20 +1,20 @@
 package com.workhub.cs.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
-@NoArgsConstructor
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "cs_qna")
 @Entity
-public class CsQna {
+public class CsQna extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,12 +23,6 @@ public class CsQna {
 
     @Column(name = "qna_content", columnDefinition = "TEXT")
     private String qnaContent;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Column(name = "cs_post_id")
     private Long csPostId;

--- a/src/main/java/com/workhub/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/workhub/global/entity/BaseTimeEntity.java
@@ -1,0 +1,32 @@
+package com.workhub.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/workhub/post/entity/Comment.java
+++ b/src/main/java/com/workhub/post/entity/Comment.java
@@ -1,21 +1,21 @@
 package com.workhub.post.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
 @Table(name = "comment")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,12 +23,6 @@ public class Comment {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     @Column(name = "post_id", nullable = false)
     private Long postId;

--- a/src/main/java/com/workhub/post/entity/Post.java
+++ b/src/main/java/com/workhub/post/entity/Post.java
@@ -1,21 +1,21 @@
 package com.workhub.post.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
 @Table(name = "post")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Post {
+public class Post extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,12 +30,6 @@ public class Post {
 
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "hashtag", nullable = false)

--- a/src/main/java/com/workhub/post/entity/PostFile.java
+++ b/src/main/java/com/workhub/post/entity/PostFile.java
@@ -1,20 +1,19 @@
 package com.workhub.post.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "post_file")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PostFile {
+public class PostFile extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,9 +24,6 @@ public class PostFile {
 
     @Column(name = "file_name", nullable = false)
     private String fileName; // 파일 이름
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt; // 생성일
 
     @Column(name = "post_id", nullable = false)
     private Long post; // 게시글

--- a/src/main/java/com/workhub/project/entity/Project.java
+++ b/src/main/java/com/workhub/project/entity/Project.java
@@ -1,22 +1,22 @@
 package com.workhub.project.entity;
 
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
 @Table(name = "project")
-public class Project {
+public class Project extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "project_id")
@@ -27,13 +27,6 @@ public class Project {
 
     @Column(name = "project_description", columnDefinition = "TEXT")
     private String projectDescription;
-
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")

--- a/src/main/java/com/workhub/projectNode/ProjectNode.java
+++ b/src/main/java/com/workhub/projectNode/ProjectNode.java
@@ -1,17 +1,19 @@
 package com.workhub.projectNode;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
 @Table(name = "project_node")
-public class ProjectNode {
+public class ProjectNode extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "project_node_id")
@@ -39,12 +41,6 @@ public class ProjectNode {
 
     @Column(name = "node_order")
     private Integer nodeOrder;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/src/main/java/com/workhub/projectNode/ProjectNodeHistory.java
+++ b/src/main/java/com/workhub/projectNode/ProjectNodeHistory.java
@@ -1,30 +1,27 @@
 package com.workhub.projectNode;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
 @Table(name = "project_node_history")
-public class ProjectNodeHistory {
+public class ProjectNodeHistory extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "project_node_history_id")
     private Long projectNodeHistoryId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status")
     private Status status;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     @Column(name = "comment", columnDefinition = "TEXT")
     private String comment;

--- a/src/main/java/com/workhub/projectNotification/entity/ProjectNotification.java
+++ b/src/main/java/com/workhub/projectNotification/entity/ProjectNotification.java
@@ -1,20 +1,21 @@
 package com.workhub.projectNotification.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "project_notification")
 @Entity
-public class ProjectNotification {
+public class ProjectNotification extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,9 +34,6 @@ public class ProjectNotification {
 
     @Column(name = "related_url", length = 100)
     private String relatedUrl;
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 
     @Column(name = "read_at")
     private LocalDateTime readAt;

--- a/src/main/java/com/workhub/userTable/entity/Company.java
+++ b/src/main/java/com/workhub/userTable/entity/Company.java
@@ -1,22 +1,20 @@
 package com.workhub.userTable.entity;
 
-import com.workhub.post.entity.PostType;
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 
 @Entity
 @Table(name = "company")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Company {
+public class Company extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,13 +25,6 @@ public class Company {
 
     @Column(name = "company_number", nullable = false, length = 20)
     private String companyNumber;
-
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     @Column(name = "tel", nullable = false, length = 20)
     private String tel;

--- a/src/main/java/com/workhub/userTable/entity/UserTable.java
+++ b/src/main/java/com/workhub/userTable/entity/UserTable.java
@@ -1,20 +1,19 @@
 package com.workhub.userTable.entity;
 
+import com.workhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "usertable")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserTable {
+public class UserTable extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer userId;
@@ -38,12 +37,6 @@ public class UserTable {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private Status status;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     @Column(name = "company_id", nullable = false)
     private Long companyId;


### PR DESCRIPTION
## PR 요약
- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
- global/entity/BaseTimeEntity: 공통 생성·수정일을 유지하는 베이스 엔티티를 정의하고 감사 리스너를 적용했습니다.
 - post/*, project/*, projectNode/*, projectNotification/*, cs/*, userTable/*: 각 엔티티가 BaseTimeEntity를 상속하도록 수정하고 Lombok @SuperBuilder로 빌더 호환성을 유
    지했습니다.

---

## 체크리스트

### 코드 품질
- [ ] 코드가 정상적으로 빌드됩니다.
- [ ] 로컬 테스트를 통과했습니다.
- [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [ ] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [ ] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [x] 관련 이슈 번호를 연결했습니다. Closes #45 
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
