### PR TITLE
fix : 여러 파일 업로드 및 다운로드 url 구현(#23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,11 @@ jobs:
 
       - name: Run tests
         run: ./gradlew clean test --build-cache
+
+      - name: Upload Test Report (if tests failed)
+        uses: actions/upload-artifact@v4 # 아티팩트 업로드 액션 사용
+        if: always() # 테스트가 실패했더라도 이 단계는 항상 실행되도록 설정
+        with:
+          name: test-reports-${{ github.sha }} # 아티팩트 파일 이름 (고유 ID 포함)
+          path: build/reports/tests/test/ # 업로드할 리포트 파일 디렉토리 경로
+          retention-days: 7 # 아티팩트 보존 기간 (선택 사항)

--- a/src/main/java/com/workhub/file/api/FileApi.java
+++ b/src/main/java/com/workhub/file/api/FileApi.java
@@ -10,10 +10,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "File", description = "파일 업로드 및 다운로드 API")
 public interface FileApi {
@@ -38,9 +40,9 @@ public interface FileApi {
             )
     })
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<FileUploadResponse> uploadFile(
+    public ApiResponse<List<FileUploadResponse>> uploadFile(
             @Parameter(description = "업로드할 파일", required = true)
-            @RequestParam("file") MultipartFile file
+            @RequestPart("file") List<MultipartFile> files
     );
 
     @Operation(
@@ -62,9 +64,9 @@ public interface FileApi {
                     description = "서버 오류 (Presigned URL 생성 실패)"
             )
     })
-    @GetMapping("/{fileName}")
-    public ApiResponse<FileUploadResponse> getFileUrl(
-            @Parameter(description = "S3에 저장된 파일명", required = true, example = "550e8400-e29b-41d4-a716-446655440000.jpg")
-            @PathVariable String fileName
+    @GetMapping("/get-files")
+    public ApiResponse<List<FileUploadResponse>> getFileUrl(
+            @Parameter(description = "S3에 저장된 파일명 리스트", required = true, example = "87bf751a-bbf0-4670-a49e-1950ec7f8be9.pdf")
+            @RequestParam("fileNames") List<String> fileNames
     );
 }

--- a/src/main/java/com/workhub/file/controller/FileController.java
+++ b/src/main/java/com/workhub/file/controller/FileController.java
@@ -9,6 +9,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/files")
 @RequiredArgsConstructor
@@ -17,16 +19,16 @@ public class FileController implements FileApi {
     private final S3Service s3Service;
 
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<FileUploadResponse> uploadFile(@RequestParam("file") MultipartFile file) {
+    public ApiResponse<List<FileUploadResponse>> uploadFile(@RequestPart("file") List<MultipartFile> files) {
 
-        String fileName = s3Service.uploadFile(file);
-        return ApiResponse.success(new FileUploadResponse(fileName, ""));
+        List<FileUploadResponse> fileName = s3Service.uploadFiles(files);
+        return ApiResponse.success(fileName);
     }
 
-    @GetMapping("/{fileName}")
-    public ApiResponse<FileUploadResponse> getFileUrl(@PathVariable String fileName) {
+    @GetMapping("/get-files")
+    public ApiResponse<List<FileUploadResponse>> getFileUrl(@RequestParam("fileNames") List<String> fileNames) {
 
-        String presignedUrl = s3Service.getPresignedUrl(fileName);
-        return ApiResponse.success(new FileUploadResponse(fileName, presignedUrl));
+        List<FileUploadResponse> presignedUrls = s3Service.getPresignedUrls(fileNames);
+        return ApiResponse.success(presignedUrls);
     }
 }

--- a/src/main/java/com/workhub/file/dto/FileUploadResponse.java
+++ b/src/main/java/com/workhub/file/dto/FileUploadResponse.java
@@ -1,3 +1,8 @@
 package com.workhub.file.dto;
 
-public record FileUploadResponse(String fileName, String presignedUrl) {}
+public record FileUploadResponse(String fileName, String presignedUrl) {
+
+    public static FileUploadResponse from(String fileName, String presignedUrl) {
+        return new FileUploadResponse(fileName, presignedUrl);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
     multipart:
       max-file-size: 50MB
       max-request-size: 50MB
+
+file:
+  upload:
+    max-size: 52428800  # 50MB


### PR DESCRIPTION
  ## PR 요약 #23 
  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

  - [x] 기능 추가
  - [ ] 버그 수정
  - [x] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ---

  ## 주요 변경 사항
  > 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

  - `FileController.java`: GET `/get-files` 엔드포인트를 RequestBody에서 RequestParam 방식으로 변경하여 RESTful API 표준 준수
  - `FileApi.java`: Swagger API 명세를 RequestParam 방식으로 수정 및 불필요한 import 제거
  - `S3Service.java`: `getPresignedUrls` 메서드 시그니처를 `List<GetDownloadRequest>`에서 `List<String>`으로 변경하여 간소화
  - `S3ServiceTest.java`: 전체 테스트 코드를 처음부터 재작성하여 public API 중심으로 테스트 구성 (uploadFiles, getPresignedUrls 메서드)

  ---

  ## 체크리스트

  ### 코드 품질
  - [x] 코드가 정상적으로 빌드됩니다.
  - [x] 로컬 테스트를 통과했습니다.
  - [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
  - [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

  ### 기능 검증
  - [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
  - [x] 예외 상황을 고려한 테스트를 진행했습니다.
  - [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

  ### 문서 및 이슈 연동
  - [ ] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
  - [x] 변경된 부분을 `README` 또는 문서에 반영했습니다.

  ---

  ## 참고 사항
  > 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

  ### API 엔드포인트 변경
  **변경 전:**
  GET /api/v1/files/get-files
  Content-Type: application/json
  Body: [{"fileName": "file1.pdf"}, {"fileName": "file2.pdf"}]

  **변경 후:**
  GET /api/v1/files/get-files?fileNames=file1.pdf&fileNames=file2.pdf

  ### 로컬 테스트 방법
  ```bash
  # 테스트 실행
  ./gradlew test --tests S3ServiceTest
```

  # 단일 파일 URL 조회
  GET /api/v1/files/get-files?fileNames=example.pdf

  # 여러 파일 URL 조회
  GET /api/v1/files/get-files?fileNames=file1.pdf&fileNames=file2.pdf&fileNames=file3.png

  주요 개선 사항

  - HTTP GET 메서드에서 RequestBody 사용하던 비표준 방식을 RequestParam으로 변경하여 RESTful API 표준 준수
  - URL 캐싱 및 브라우저 북마크 가능
  - GetDownloadRequest DTO 제거로 코드 간소화
  - 테스트 코드 전면 개선 (15개 테스트 케이스로 구성)

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
