### PR TITLE
feat: CS Post 수정 기능 및 유효성 검증 구현 (#10)

### DIFF
--- a/src/main/java/com/workhub/cs/controller/CsPostController.java
+++ b/src/main/java/com/workhub/cs/controller/CsPostController.java
@@ -2,6 +2,7 @@ package com.workhub.cs.controller;
 
 import com.workhub.cs.dto.CsPostRequest;
 import com.workhub.cs.dto.CsPostResponse;
+import com.workhub.cs.dto.CsPostUpdateRequest;
 import com.workhub.cs.service.CsPostService;
 import com.workhub.global.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -35,5 +36,24 @@ public class CsPostController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.created(response, "CS 게시글이 작성되었습니다."));
+    }
+
+    /**
+     * 프로젝트의 CS 게시글을 수정한다.
+     * @param projectId
+     * @param csPostUpdateRequest
+     * @return
+     */
+    @PatchMapping("/{projectId}/csPosts/{csPostId}")
+    public ResponseEntity<ApiResponse<CsPostResponse>> updateCsPost(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId,
+            @Valid @RequestBody CsPostUpdateRequest csPostUpdateRequest
+    ) {
+        // todo : security 기능 구현시 userId security에서 꺼내서 넘겨야 함
+        CsPostResponse response = csPostService.update(projectId, csPostId, csPostUpdateRequest);
+
+        return ResponseEntity
+                .ok(ApiResponse.success(response, "CS 게시글이 수정되었습니다."));
     }
 }

--- a/src/main/java/com/workhub/cs/dto/CsPostFileUpdateRequest.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostFileUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.workhub.cs.dto;
+
+public record CsPostFileUpdateRequest() {
+}

--- a/src/main/java/com/workhub/cs/dto/CsPostFileUpdateRequest.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostFileUpdateRequest.java
@@ -1,4 +1,10 @@
 package com.workhub.cs.dto;
 
-public record CsPostFileUpdateRequest() {
+public record CsPostFileUpdateRequest(
+        Long fileId,
+        String fileUrl,
+        String fileName,
+        Integer fileOrder,
+        boolean deleted
+) {
 }

--- a/src/main/java/com/workhub/cs/dto/CsPostResponse.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostResponse.java
@@ -2,27 +2,21 @@ package com.workhub.cs.dto;
 
 import com.workhub.cs.entity.CsPost;
 import com.workhub.cs.entity.CsPostFile;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
-@Getter
-public class CsPostResponse {
-
-    private Long csPostId;
-    private LocalDateTime deletedAt;
-    private String title;
-    private String content;
-    private Long userId;
-    private List<CsPostFileResponse> files;
+public record CsPostResponse(
+        Long csPostId,
+        LocalDateTime deletedAt,
+        String title,
+        String content,
+        Long userId,
+        List<CsPostFileResponse> files
+) {
 
     public static CsPostResponse from(CsPost post, List<CsPostFile> fileList) {
 

--- a/src/main/java/com/workhub/cs/dto/CsPostUpdateRequest.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.workhub.cs.dto;
+
+public record CsPostUpdateRequest() {
+}

--- a/src/main/java/com/workhub/cs/dto/CsPostUpdateRequest.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostUpdateRequest.java
@@ -1,4 +1,17 @@
 package com.workhub.cs.dto;
 
-public record CsPostUpdateRequest() {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CsPostUpdateRequest(
+        @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다.")
+        String title,
+
+        @NotBlank(message = "내용은 필수 입력값입니다.")
+        String content,
+
+        List<CsPostFileUpdateRequest> files
+) {
 }

--- a/src/main/java/com/workhub/cs/entity/CsPost.java
+++ b/src/main/java/com/workhub/cs/entity/CsPost.java
@@ -1,7 +1,10 @@
 package com.workhub.cs.entity;
 
 import com.workhub.cs.dto.CsPostRequest;
+import com.workhub.cs.dto.CsPostUpdateRequest;
 import com.workhub.global.entity.BaseTimeEntity;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -45,5 +48,26 @@ public class CsPost extends BaseTimeEntity {
                 .title(request.title())
                 .content(request.content())
                 .build();
+    }
+
+    public static CsPost of(Long projectId, CsPostUpdateRequest request) {
+        return CsPost.builder()
+                .title(request.title())
+                .content(request.content())
+                .build();
+    }
+
+    public void updateTitle(String newTitle) {
+        if (newTitle == null && newTitle.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_CS_POST_TITLE);
+        }
+        this.title = newTitle;
+    }
+
+    public void updateContent(String newContent) {
+        if (newContent == null && newContent.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_CS_POST_CONTENT);
+        }
+        this.content = newContent;
     }
 }

--- a/src/main/java/com/workhub/cs/entity/CsPostFile.java
+++ b/src/main/java/com/workhub/cs/entity/CsPostFile.java
@@ -1,12 +1,17 @@
 package com.workhub.cs.entity;
 
 import com.workhub.cs.dto.CsPostFileRequest;
+import com.workhub.cs.dto.CsPostFileUpdateRequest;
 import com.workhub.global.entity.BaseTimeEntity;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
 
 @Getter
 @SuperBuilder
@@ -33,6 +38,9 @@ public class CsPostFile extends BaseTimeEntity {
     @Column(name = "cs_post_id")
     private Long csPostId;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public static CsPostFile of(Long csPostId, CsPostFileRequest request) {
         return CsPostFile.builder()
                 .csPostId(csPostId)
@@ -40,5 +48,38 @@ public class CsPostFile extends BaseTimeEntity {
                 .fileName(request.fileName())
                 .fileOrder(request.fileOrder())
                 .build();
+    }
+
+    public static CsPostFile of(Long csPostId, CsPostFileUpdateRequest request) {
+        return CsPostFile.builder()
+                .csPostId(csPostId)
+                .fileUrl(request.fileUrl())
+                .fileName(request.fileName())
+                .fileOrder(request.fileOrder())
+                .build();
+    }
+
+    /**
+     * 파일 삭제
+     */
+    public void markDeleted() {
+        this.deletedAt = (LocalDateTime.now());
+    }
+
+    /**
+     * 파일 순서 변경
+     */
+    public void updateOrder(Integer newOrder) {
+        this.fileOrder = validateOrder(newOrder);
+    }
+
+    /**
+     * 순서 검증
+     */
+    private static Integer validateOrder(Integer order) {
+        if (order == null || order < 0) {
+            throw new BusinessException(ErrorCode.INVALID_CS_POST_FILE_ORDER);
+        }
+        return order;
     }
 }

--- a/src/main/java/com/workhub/cs/repository/CsPostFileRepository.java
+++ b/src/main/java/com/workhub/cs/repository/CsPostFileRepository.java
@@ -3,5 +3,9 @@ package com.workhub.cs.repository;
 import com.workhub.cs.entity.CsPostFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CsPostFileRepository extends JpaRepository<CsPostFile, Long> {
+
+    List<CsPostFile> findByCsPostId(Long csPostId);
 }

--- a/src/main/java/com/workhub/cs/service/CsPostService.java
+++ b/src/main/java/com/workhub/cs/service/CsPostService.java
@@ -1,18 +1,22 @@
 package com.workhub.cs.service;
 
-import com.workhub.cs.dto.CsPostFileRequest;
+import com.workhub.cs.dto.CsPostFileUpdateRequest;
 import com.workhub.cs.dto.CsPostRequest;
 import com.workhub.cs.dto.CsPostResponse;
+import com.workhub.cs.dto.CsPostUpdateRequest;
 import com.workhub.cs.entity.CsPost;
 import com.workhub.cs.entity.CsPostFile;
 import com.workhub.cs.repository.CsPostFileRepository;
 import com.workhub.cs.repository.CsPostRepository;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.project.validator.ProjectValidator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +26,7 @@ public class CsPostService {
     private final CsPostRepository csPostRepository;
     private final CsPostFileRepository csPostFileRepository;
 
-//    private final ProjectValidator projectValidator;
+    private final ProjectValidator projectValidator;
 //    private final UserValidator userValidator;
 
     /**
@@ -33,21 +37,150 @@ public class CsPostService {
      */
     public CsPostResponse create(Long projectId, CsPostRequest request) {
 
-        // todo : userId, projectId 검증 validator 로직 필요
-        // todo : project가 끝난 상태인지, 존재하는 프로젝트인지 확인 필요
-        CsPost post = csPostRepository.save(CsPost.of(projectId, request));
+        // todo : userId 검증 필요 + 추후 시큐리티 연동 후 구현 예정
+        projectValidator.validateExistsProject(projectId);
+        projectValidator.validateContractEndDate(projectId);
+
+        CsPost csPost = csPostRepository.save(CsPost.of(projectId, request));
 
         List<CsPostFile> files = List.of();
 
         if (request.files() != null && !request.files().isEmpty()) {
 
             files = request.files().stream()
-                    .map(f -> CsPostFile.of(post.getCsPostId(), f))
+                    .map(f -> CsPostFile.of(csPost.getCsPostId(), f))
                     .toList();
 
             csPostFileRepository.saveAll(files);
         }
 
-        return CsPostResponse.from(post, files);
+        return CsPostResponse.from(csPost, files);
+    }
+
+    /**
+     * 게시글을 업데이트합니다.
+     * @param projectId
+     * @param csPostId
+     * @param request
+     * @return
+     */
+    public CsPostResponse update(Long projectId, Long csPostId, CsPostUpdateRequest request) {
+        // todo : 게시글을 등록한 사용자가 맞는지 확인 필요 + 추후 시큐리티 연동 후 구현 예정
+
+        projectValidator.validateExistsProject(projectId);
+        projectValidator.validateContractEndDate(projectId);
+
+        CsPost csPost = getAndValidatePost(projectId, csPostId);
+
+        updatePost(csPost, request);
+
+        List<CsPostFile> updatedFiles = updateFiles(csPostId, request.files());
+
+        // 삭제되지 않은 파일만 응답
+        List<CsPostFile> visibleFiles = updatedFiles.stream().filter(
+                file -> file.getDeletedAt() == null).toList();
+
+        return CsPostResponse.from(csPost, visibleFiles);
+    }
+
+    /**
+     * 파일이 존재하면 업데이트 (삭제, 추가, 유지)
+     * @param csPostId
+     * @param fileRequests
+     * @return
+     */
+    private List<CsPostFile> updateFiles(Long csPostId, List<CsPostFileUpdateRequest> fileRequests) {
+
+        // 기존 파일 조회
+        List<CsPostFile> existingFiles = csPostFileRepository.findByCsPostId(csPostId);
+
+        // 요청 파일이 없으면 기존 파일 그대로 반환
+        if (fileRequests == null || fileRequests.isEmpty()) {
+            return existingFiles;
+        }
+
+        // 기존 파일을 Map으로 바꾸기
+        Map<Long, CsPostFile> existingFileMap = existingFiles.stream()
+                .collect(Collectors.toMap(
+                        CsPostFile::getCsPostFileId,
+                        file -> file
+                ));
+
+        // 요청으로 받은 파일들 중 filedId 만 모으기
+        Set<Long> requestedIds = fileRequests.stream()
+                .map(CsPostFileUpdateRequest::fileId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        // 기존 파일 중 요청에 없는 파일은 삭제
+        for (CsPostFile existingFile : existingFiles) {
+            if (!requestedIds.contains(existingFile.getCsPostFileId())) {
+                existingFile.markDeleted();
+            }
+        }
+
+        List<CsPostFile> resultFiles = new ArrayList<>();
+
+        for (CsPostFileUpdateRequest req : fileRequests) {
+            if (req.fileId() == null) {
+                if (req.deleted()) {
+                    throw new BusinessException(ErrorCode.INVALID_FILE_UPDATE);
+                }
+                CsPostFile newFile = CsPostFile.of(csPostId, req);
+                resultFiles.add(csPostFileRepository.save(newFile));
+                continue;
+            }
+
+            CsPostFile target = existingFileMap.get(req.fileId());
+            if (target == null) {
+                throw new BusinessException(ErrorCode.NOT_EXISTS_CS_POST_FILE);
+            }
+            if (req.deleted()) {
+                target.markDeleted();
+                continue;
+            }
+
+            // 유지 or 순서 업데이트
+            target.updateOrder(req.fileOrder());
+            resultFiles.add(target);
+        }
+
+        return resultFiles;
+    }
+
+    /**
+     * 게시물 제목 + 내용 수정
+     * @param csPost
+     * @param request
+     */
+    private void updatePost(CsPost csPost, CsPostUpdateRequest request) {
+        if (request.title() != null && !request.title().isBlank()) {
+            csPost.updateTitle(request.title());
+        }
+
+        if (request.content() != null && !request.content().isBlank()) {
+            csPost.updateContent(request.content());
+        }
+
+        csPostRepository.save(csPost);
+    }
+
+    /**
+     * 게시글 조회 + 프로젝트 소속 검증
+     * @param projectId
+     * @param csPostId
+     * @return
+     */
+    private CsPost getAndValidatePost(Long projectId, Long csPostId) {
+
+        CsPost post = csPostRepository.findById(csPostId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXISTS_CS_POST));
+
+        // 프로젝트 소속 검증
+        if (!projectId.equals(post.getProjectId())) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_PROJECT_CS_POST);
+        }
+
+        return post;
     }
 }

--- a/src/main/java/com/workhub/cs/validator/CsPostValidator.java
+++ b/src/main/java/com/workhub/cs/validator/CsPostValidator.java
@@ -1,20 +1,4 @@
 package com.workhub.cs.validator;
 
-import com.workhub.cs.repository.CsPostRepository;
-import com.workhub.global.error.ErrorCode;
-import com.workhub.global.error.exception.BusinessException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-
-@RequiredArgsConstructor
-@Component
-public class CsPostValidator {
-
-    private final CsPostRepository csPostRepository;
-
-    public void validateExists(Long csPostId){
-        if (!csPostRepository.existsById(csPostId)){
-            throw new BusinessException(ErrorCode.NOT_EXISTS_CS_POST);
-        }
-    }
+public interface CsPostValidator {
 }

--- a/src/main/java/com/workhub/cs/validator/CsPostValidator.java
+++ b/src/main/java/com/workhub/cs/validator/CsPostValidator.java
@@ -1,4 +1,5 @@
 package com.workhub.cs.validator;
 
 public interface CsPostValidator {
+    void validateExistsCsPostId(Long csPostId);
 }

--- a/src/main/java/com/workhub/cs/validator/CsPostValidatorImpl.java
+++ b/src/main/java/com/workhub/cs/validator/CsPostValidatorImpl.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-public class CsPostValidator {
+public class CsPostValidatorImpl implements CsPostValidator {
 
     private final CsPostRepository csPostRepository;
 

--- a/src/main/java/com/workhub/cs/validator/CsPostValidatorImpl.java
+++ b/src/main/java/com/workhub/cs/validator/CsPostValidatorImpl.java
@@ -1,0 +1,20 @@
+package com.workhub.cs.validator;
+
+import com.workhub.cs.repository.CsPostRepository;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class CsPostValidator {
+
+    private final CsPostRepository csPostRepository;
+
+    public void validateExistsCsPostId(Long csPostId){
+        if (!csPostRepository.existsById(csPostId)) {
+            throw new BusinessException(ErrorCode.NOT_EXISTS_CS_POST);
+        }
+    }
+}

--- a/src/main/java/com/workhub/global/error/ErrorCode.java
+++ b/src/main/java/com/workhub/global/error/ErrorCode.java
@@ -51,7 +51,6 @@ public enum ErrorCode {
     INVALID_CS_POST_FILE_UPDATE(HttpStatus.BAD_REQUEST, "C-006", "잘못된 파일 업데이트 요청입니다."),
     INVALID_CS_POST_FILE_ORDER(HttpStatus.BAD_REQUEST, "C-007", "파일 순서(fileOrder)는 0 이상의 값이어야 합니다."),
     INVALID_FILE_UPDATE(HttpStatus.BAD_REQUEST, "C-008", "잘못된 파일 수정 요청입니다."),
-    NOT_EXISTS_CS_POST(HttpStatus.BAD_REQUEST, "C-001", "존재하지 않는 CS 게시물입니다."),
 
     // AWS S3
     // 파일 관련 에러

--- a/src/main/java/com/workhub/global/error/ErrorCode.java
+++ b/src/main/java/com/workhub/global/error/ErrorCode.java
@@ -41,7 +41,16 @@ public enum ErrorCode {
 
     // 게시물
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "PO-001", "게시물을 찾을 수 없습니다."),
+
     // CS 게시판
+    NOT_EXISTS_CS_POST(HttpStatus.BAD_REQUEST, "C-001", "존재하지 않는 CS 게시물입니다."),
+    NOT_MATCHED_PROJECT_CS_POST(HttpStatus.BAD_REQUEST, "C-002", "잘못된 프로젝트의 게시글입니다."),
+    INVALID_CS_POST_TITLE(HttpStatus.BAD_REQUEST, "C-003", "Title이 없습니다."),
+    INVALID_CS_POST_CONTENT(HttpStatus.BAD_REQUEST, "C-004", "Content가 없습니다."),
+    NOT_EXISTS_CS_POST_FILE(HttpStatus.BAD_REQUEST, "C-005", "존재하지 않는 CS 파일입니다."),
+    INVALID_CS_POST_FILE_UPDATE(HttpStatus.BAD_REQUEST, "C-006", "잘못된 파일 업데이트 요청입니다."),
+    INVALID_CS_POST_FILE_ORDER(HttpStatus.BAD_REQUEST, "C-007", "파일 순서(fileOrder)는 0 이상의 값이어야 합니다."),
+    INVALID_FILE_UPDATE(HttpStatus.BAD_REQUEST, "C-008", "잘못된 파일 수정 요청입니다."),
     NOT_EXISTS_CS_POST(HttpStatus.BAD_REQUEST, "C-001", "존재하지 않는 CS 게시물입니다."),
 
     // AWS S3
@@ -52,7 +61,7 @@ public enum ErrorCode {
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "F-004", "지원하지 않는 파일 형식입니다."),
     INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "F-005", "파일 이름이 누락되었습니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F-006", "파일 크기가 제한을 초과했습니다."),
-    FILE_ACCESS_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "F-007", "파일 접근에 실패했습니다."),;
+    FILE_ACCESS_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "F-007", "파일 접근에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/com/workhub/project/validator/ProjectValidator.java
+++ b/src/main/java/com/workhub/project/validator/ProjectValidator.java
@@ -1,0 +1,4 @@
+package com.workhub.project.validator;
+
+public interface ProjectValidator {
+}

--- a/src/main/java/com/workhub/project/validator/ProjectValidator.java
+++ b/src/main/java/com/workhub/project/validator/ProjectValidator.java
@@ -1,4 +1,6 @@
 package com.workhub.project.validator;
 
 public interface ProjectValidator {
+    void validateExistsProject(Long projectId);
+    void validateContractEndDate(Long projectId);
 }

--- a/src/main/java/com/workhub/project/validator/ProjectValidatorImpl.java
+++ b/src/main/java/com/workhub/project/validator/ProjectValidatorImpl.java
@@ -1,0 +1,4 @@
+package com.workhub.project.validator;
+
+public class ProjectValidatorImpl {
+}

--- a/src/main/java/com/workhub/project/validator/ProjectValidatorImpl.java
+++ b/src/main/java/com/workhub/project/validator/ProjectValidatorImpl.java
@@ -1,4 +1,17 @@
 package com.workhub.project.validator;
 
-public class ProjectValidatorImpl {
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProjectValidatorImpl implements ProjectValidator {
+
+    @Override
+    public void validateExistsProject(Long projectId) {
+
+    }
+
+    @Override
+    public void validateContractEndDate(Long projectId) {
+
+    }
 }


### PR DESCRIPTION
## PR 요약
CS POST 게시글 수정 기능을 구현하고, 프로젝트/고객지원 게시글에 대한 Validator를 도입하여 도메인 간 직접 의존 없이 유효성 검증을 수행할 수 있도록 개선했습니다.

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
- CsPostUpdateRequest, CsPostFileUpdateRequest
게시글 수정 요청 DTO 신규 생성
파일 정보 수정(유지/삭제)을 위한 구조 정립
- CsPostValidator, CsPostValidatorImpl
게시글 존재 여부, 작성자 검증 로직 분리
서비스에서 Repository 직접 접근을 최소화
ProjectValidator, ProjectValidatorImpl
타 도메인 접근 없는 프로젝트 유효성 검증 구조 확립
- CsPostService
수정 로직 전체 리팩토링
기존 파일 목록과 요청 파일 목록 비교하여 삭제 처리 (markDeleted()) 적용
Validator 적용으로 도메인 간 결합도 감소
- 테스트 코드(CsPostServiceTest)
CS POST 수정 테스트 추가
테스트 안정성 강화

---

## 체크리스트

### 코드 품질
- [x] 코드가 정상적으로 빌드됩니다.
- [x] 로컬 테스트를 통과했습니다.
- [ ] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [x] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [x] 관련 이슈 번호를 연결했습니다. 
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 참고 사항
- 게시글 파일 수정 로직은 기존 파일 리스트와 요청 파일 리스트 비교 후, 요청에 포함되지 않은 기존 파일은 markDeleted() 처리됩니다.
- ProjectValidator, CsPostValidator 도입으로 도메인 간 직접 참조를 피하면서 유효성 검증이 가능해졌습니다.

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
