### PR TITLE
refactor : CS POST 파일 관련 url 삭제 (#10)

### DIFF
--- a/src/main/java/com/workhub/cs/dto/CsPostFileRequest.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostFileRequest.java
@@ -3,7 +3,6 @@ package com.workhub.cs.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record CsPostFileRequest(
-        @NotBlank String fileUrl,
         @NotBlank String fileName,
         Integer fileOrder
 ) {

--- a/src/main/java/com/workhub/cs/dto/CsPostFileResponse.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostFileResponse.java
@@ -4,14 +4,12 @@ import com.workhub.cs.entity.CsPostFile;
 
 public record CsPostFileResponse(
         Long csPostFileId,
-        String fileUrl,
         String fileName,
         Integer fileOrder
 ) {
     public static CsPostFileResponse from(CsPostFile file) {
         return new CsPostFileResponse(
                 file.getCsPostFileId(),
-                file.getFileUrl(),
                 file.getFileName(),
                 file.getFileOrder()
         );

--- a/src/main/java/com/workhub/cs/dto/CsPostFileUpdateRequest.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostFileUpdateRequest.java
@@ -2,7 +2,6 @@ package com.workhub.cs.dto;
 
 public record CsPostFileUpdateRequest(
         Long fileId,
-        String fileUrl,
         String fileName,
         Integer fileOrder,
         boolean deleted

--- a/src/main/java/com/workhub/cs/entity/CsPostFile.java
+++ b/src/main/java/com/workhub/cs/entity/CsPostFile.java
@@ -45,7 +45,6 @@ public class CsPostFile extends BaseTimeEntity {
     public static CsPostFile of(Long csPostId, CsPostFileRequest request) {
         return CsPostFile.builder()
                 .csPostId(csPostId)
-                .fileUrl(request.fileUrl())
                 .fileName(request.fileName())
                 .fileOrder(request.fileOrder())
                 .build();
@@ -54,7 +53,6 @@ public class CsPostFile extends BaseTimeEntity {
     public static CsPostFile of(Long csPostId, CsPostFileUpdateRequest request) {
         return CsPostFile.builder()
                 .csPostId(csPostId)
-                .fileUrl(request.fileUrl())
                 .fileName(request.fileName())
                 .fileOrder(request.fileOrder())
                 .build();

--- a/src/test/java/com/workhub/cs/service/CsPostServiceTest.java
+++ b/src/test/java/com/workhub/cs/service/CsPostServiceTest.java
@@ -81,8 +81,8 @@ public class CsPostServiceTest {
         Long projectId = 1L;
 
         List<CsPostFileRequest> fileRequests = Arrays.asList(
-                new CsPostFileRequest("url1", "file1", 1),
-                new CsPostFileRequest("url2", "file2", 2)
+                new CsPostFileRequest("url1",  1),
+                new CsPostFileRequest("url2",  2)
         );
 
         CsPostRequest request =


### PR DESCRIPTION
## PR 요약
CS POST 파일 내에 file url은 S3로 요청을 보내기에 속성 삭제하였습니다. 

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
dto 및 dto 변경 로직에서 fileUrl 제거

src/main/java/com/workhub/cs/dto/CsPostFileRequest.java
src/main/java/com/workhub/cs/dto/CsPostFileResponse.java
src/main/java/com/workhub/cs/dto/CsPostFileUpdateRequest.java
src/main/java/com/workhub/cs/entity/CsPostFile.java
src/test/java/com/workhub/cs/service/CsPostServiceTest.java

---

## 체크리스트

### 코드 품질
- [x] 코드가 정상적으로 빌드됩니다.
- [x] 로컬 테스트를 통과했습니다.
- [ ] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [ ] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
