### PR TITLE
feat : CS POST 게시물 삭제 구현 (#10)

### DIFF
--- a/src/main/java/com/workhub/cs/api/CsPostApi.java
+++ b/src/main/java/com/workhub/cs/api/CsPostApi.java
@@ -13,11 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "CS 게시글 관리", description = "프로젝트 CS 게시물 API")
 @RequestMapping("/api/v1/projects/{projectId}/csPosts")
@@ -70,4 +66,34 @@ public interface CsPostApi {
             @PathVariable Long csPostId,
             @Valid @RequestBody CsPostUpdateRequest csPostUpdateRequest
     );
+
+    @Operation(
+            summary = "CS 게시글 삭제",
+            description = "CS 게시글을 Soft Delete 방식으로 삭제합니다. (deletedAt 설정)",
+            parameters = {
+                    @Parameter(name = "projectId", description = "프로젝트 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "csPostId", description = "CS 게시글 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "CS 게시글 삭제 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = Long.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CS 게시글을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 부족(추후 Security 적용 시)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping(
+            value = "/{csPostId}",
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    ApiResponse<Long> deleteCsPost(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId
+    );
+
+
 }

--- a/src/main/java/com/workhub/cs/controller/CsPostController.java
+++ b/src/main/java/com/workhub/cs/controller/CsPostController.java
@@ -57,4 +57,21 @@ public class CsPostController implements CsPostApi {
 
         return ApiResponse.success(response, "CS 게시글이 수정되었습니다.");
     }
+
+    /**
+     *  프로젝트의 CS 게시물을 삭제한다.
+     * @param projectId
+     * @param csPostId
+     * @return
+     */
+    @Override
+    @DeleteMapping("/{csPostId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<Long> deleteCsPost(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId
+    ) {
+        // todo : security 기능 구현시 userId security에서 꺼내서 넘겨야 함
+        return ApiResponse.success(csPostService.delete(projectId, csPostId));
+    }
 }

--- a/src/main/java/com/workhub/cs/entity/CsPost.java
+++ b/src/main/java/com/workhub/cs/entity/CsPost.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @SuperBuilder
@@ -64,10 +65,24 @@ public class CsPost extends BaseTimeEntity {
         this.title = newTitle;
     }
 
+    public void markDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
     public void updateContent(String newContent) {
         if (newContent == null && newContent.isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_CS_POST_CONTENT);
         }
         this.content = newContent;
+    }
+
+    public void validateProject(Long requestProjectId) {
+        if (!Objects.equals(this.projectId, requestProjectId)) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_PROJECT_CS_POST);
+        }
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/workhub/cs/service/CsPostService.java
+++ b/src/main/java/com/workhub/cs/service/CsPostService.java
@@ -15,6 +15,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -81,6 +82,27 @@ public class CsPostService {
                 file -> file.getDeletedAt() == null).toList();
 
         return CsPostResponse.from(csPost, visibleFiles);
+    }
+
+    /**
+     * 게시글을 삭제합니다.
+     * @param projectId
+     * @param csPostId
+     * @return csPostId
+     */
+    public Long delete(Long projectId, Long csPostId) {
+
+        CsPost csPost = csPostRepository.findById(csPostId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXISTS_CS_POST));
+
+        if (csPost.isDeleted()) {
+            throw new BusinessException(ErrorCode.ALREADY_DELETED_CS_POST);
+        }
+
+        csPost.validateProject(projectId);
+        csPost.markDeleted();
+
+        return csPost.getCsPostId();
     }
 
     /**
@@ -183,4 +205,5 @@ public class CsPostService {
 
         return post;
     }
+
 }

--- a/src/main/java/com/workhub/global/error/ErrorCode.java
+++ b/src/main/java/com/workhub/global/error/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     INVALID_CS_POST_FILE_UPDATE(HttpStatus.BAD_REQUEST, "C-006", "잘못된 파일 업데이트 요청입니다."),
     INVALID_CS_POST_FILE_ORDER(HttpStatus.BAD_REQUEST, "C-007", "파일 순서(fileOrder)는 0 이상의 값이어야 합니다."),
     INVALID_FILE_UPDATE(HttpStatus.BAD_REQUEST, "C-008", "잘못된 파일 수정 요청입니다."),
+    ALREADY_DELETED_CS_POST(HttpStatus.BAD_REQUEST, "C-009", "이미 삭재된 CS 게시글입니다."),
 
     // AWS S3
     // 파일 관련 에러


### PR DESCRIPTION
## PR 요약
CS 게시글 삭제 API를 소프트 삭제 방식으로 구현하고 단위 테스트를 추가했습니다.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
  - `src/main/java/com/workhub/cs/service/CsPostService.java:93` : 게시글 삭제 시 존재 여부, 중복 삭제, 프로젝트 소속을 검증한 뒤 `markDeleted()`로 소프트 삭제하도록 구현했습니다.
  - `src/test/java/com/workhub/cs/service/CsPostServiceTest.java:186` : 삭제 성공/미존재 예외 시나리오를 검증하는 단위 테스트를 추가해 서비스 동작을 보장했습니다.

---

## 체크리스트

### 코드 품질
- [ ] 코드가 정상적으로 빌드됩니다.
- [ ] 로컬 테스트를 통과했습니다.
- [ ] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [ ] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [x] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [x] 관련 이슈 번호를 연결했습니다.
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
