### PR TITLE
feat : CS POST Status 변경 (#10)

### DIFF
--- a/src/main/java/com/workhub/cs/api/CsPostApi.java
+++ b/src/main/java/com/workhub/cs/api/CsPostApi.java
@@ -3,6 +3,7 @@ package com.workhub.cs.api;
 import com.workhub.cs.dto.CsPostRequest;
 import com.workhub.cs.dto.CsPostResponse;
 import com.workhub.cs.dto.CsPostUpdateRequest;
+import com.workhub.cs.entity.CsPostStatus;
 import com.workhub.global.response.ApiResponse;
 import com.workhub.userTable.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -105,5 +106,30 @@ public interface CsPostApi {
             @PathVariable Long csPostId
     );
 
-
+    @Operation(
+            summary = "CS 게시글 상태 변경",
+            description = "CS 게시글의 진행 상태(RECEIVED, IN_PROGRESS, COMPLETED)를 변경합니다.",
+            parameters = {
+                    @Parameter(name = "projectId", description = "프로젝트 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "csPostId", description = "CS 게시글 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "status", description = "변경할 CS 게시글 상태 값", in = ParameterIn.QUERY, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "CS 게시글 상태 변경 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CsPostResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CS 게시글을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 부족"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PatchMapping(value = "/{csPostId}/status", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<CsPostStatus>> changeStatus(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId,
+            @RequestParam CsPostStatus status
+    );
 }

--- a/src/main/java/com/workhub/cs/controller/CsPostController.java
+++ b/src/main/java/com/workhub/cs/controller/CsPostController.java
@@ -4,6 +4,7 @@ import com.workhub.cs.api.CsPostApi;
 import com.workhub.cs.dto.CsPostRequest;
 import com.workhub.cs.dto.CsPostResponse;
 import com.workhub.cs.dto.CsPostUpdateRequest;
+import com.workhub.cs.entity.CsPostStatus;
 import com.workhub.cs.service.CsPostService;
 import com.workhub.global.response.ApiResponse;
 import com.workhub.userTable.security.CustomUserDetails;
@@ -11,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -81,5 +83,17 @@ public class CsPostController implements CsPostApi {
     ) {
         // todo : security 기능 구현시 userId security에서 꺼내서 넘겨야 함
         return ApiResponse.success(csPostService.delete(projectId, csPostId));
+    }
+
+    @Override
+    @PreAuthorize("hasAnyRole('DEVELOPER', 'ADMIN')")
+    @PatchMapping("/{csPostId}/status")
+    public ResponseEntity<ApiResponse<CsPostStatus>> changeStatus(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId,
+            @RequestParam CsPostStatus status
+    ) {
+        CsPostStatus changed = csPostService.changeStatus(projectId, csPostId, status);
+        return ApiResponse.success(changed, "CS 게시글 상태가 변경되었습니다.");
     }
 }

--- a/src/main/java/com/workhub/cs/controller/CsPostController.java
+++ b/src/main/java/com/workhub/cs/controller/CsPostController.java
@@ -85,6 +85,13 @@ public class CsPostController implements CsPostApi {
         return ApiResponse.success(csPostService.delete(projectId, csPostId));
     }
 
+    /**
+     * 프로젝트 CS POST 상태 값을 변경한다.
+     * @param projectId
+     * @param csPostId
+     * @param status
+     * @return
+     */
     @Override
     @PreAuthorize("hasAnyRole('DEVELOPER', 'ADMIN')")
     @PatchMapping("/{csPostId}/status")

--- a/src/main/java/com/workhub/cs/entity/CsPost.java
+++ b/src/main/java/com/workhub/cs/entity/CsPost.java
@@ -33,6 +33,10 @@ public class CsPost extends BaseTimeEntity {
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cs_post_status")
+    private CsPostStatus csPostStatus;
+
     @Column(name = "project_id")
     private Long projectId;
 
@@ -77,6 +81,10 @@ public class CsPost extends BaseTimeEntity {
         if (!Objects.equals(this.projectId, requestProjectId)) {
             throw new BusinessException(ErrorCode.NOT_MATCHED_PROJECT_CS_POST);
         }
+    }
+
+    public void changeStatus(CsPostStatus newStatus) {
+        this.csPostStatus = newStatus;
     }
 
 }

--- a/src/main/java/com/workhub/cs/entity/CsPostStatus.java
+++ b/src/main/java/com/workhub/cs/entity/CsPostStatus.java
@@ -1,0 +1,4 @@
+package com.workhub.cs.entity;
+
+public enum CsPostStatus {
+}

--- a/src/main/java/com/workhub/cs/entity/CsPostStatus.java
+++ b/src/main/java/com/workhub/cs/entity/CsPostStatus.java
@@ -1,4 +1,5 @@
 package com.workhub.cs.entity;
 
 public enum CsPostStatus {
+    RECEIVED, IN_PROGRESS, COMPLETED
 }

--- a/src/main/java/com/workhub/cs/service/CsPostService.java
+++ b/src/main/java/com/workhub/cs/service/CsPostService.java
@@ -6,6 +6,7 @@ import com.workhub.cs.dto.CsPostResponse;
 import com.workhub.cs.dto.CsPostUpdateRequest;
 import com.workhub.cs.entity.CsPost;
 import com.workhub.cs.entity.CsPostFile;
+import com.workhub.cs.entity.CsPostStatus;
 import com.workhub.cs.repository.CsPostFileRepository;
 import com.workhub.cs.repository.CsPostRepository;
 import com.workhub.global.error.ErrorCode;
@@ -14,7 +15,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -81,9 +81,9 @@ public class CsPostService {
 
     /**
      * 게시글을 삭제합니다.
-     * @param projectId
-     * @param csPostId
-     * @return csPostId
+     * @param projectId 프로젝트 식별자
+     * @param csPostId 게시글 식별자
+     * @return csPostId 삭제된 게시글 식별자
      */
     public Long delete(Long projectId, Long csPostId) {
 
@@ -98,6 +98,21 @@ public class CsPostService {
         csPost.markDeleted();
 
         return csPost.getCsPostId();
+    }
+
+    /**
+     *
+     * @param projectId 프로젝트 식별자
+     * @param csPostId 게시글 식별자
+     * @param status 게시글 상태 값
+     * @return status 변경된 게시글 상태 값
+     */
+    public CsPostStatus changeStatus(Long projectId, Long csPostId, CsPostStatus status) {
+        CsPost csPost = getAndValidatePost(projectId, csPostId);
+
+        csPost.changeStatus(status);
+
+        return csPost.getCsPostStatus();
     }
 
     /**


### PR DESCRIPTION
## PR 요약
> CS POST 게시글의 상태 값을 변경합니다. 

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
- CsPostService.changeStatus()
게시글 상태값 변경 기능 추가
JPA 변경감지(Dirty Checking) 기반으로 동작하도록 save() 호출 제거
프로젝트 소속 검증(getAndValidatePost)을 공통 사용하도록 정리

- CsPostStatus 상태 컬럼 추가 

---

## 체크리스트

### 코드 품질
- [ ] 코드가 정상적으로 빌드됩니다.
- [ ] 로컬 테스트를 통과했습니다.
- [ ] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [ ] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [ ] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [ ] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [ ] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 참고 사항
## PR 요약
> CS POST

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- `파일명/모듈명`: 변경 내용 요약  
- `파일명/모듈명`: 수정 이유  

---

## 체크리스트

### 코드 품질
- [ ] 코드가 정상적으로 빌드됩니다.
- [ ] 로컬 테스트를 통과했습니다.
- [ ] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [ ] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [ ] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [ ] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [ ] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 참고 사항
상태 변경 API는 단순 리소스 업데이트이므로 RequestParam 기반으로 처리했습니다.
Security 적용 후 @PreAuthorize 기반 권한 체크 정상 동작 확인했습니다.

- CS POST 관련 엔드포인트:
- POST   /api/v1/projects/{projectId}/csPosts
- PATCH  /api/v1/projects/{projectId}/csPosts/{csPostId}
- DELETE /api/v1/projects/{projectId}/csPosts/{csPostId}
- PATCH  /api/v1/projects/{projectId}/csPosts/{csPostId}/status?status=IN_PROGRESS

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.


---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
