### PR TITLE
refactor: user 및 project검증, service 기능별 분리 (#57)

### DIFF
--- a/src/main/java/com/workhub/global/error/ErrorCode.java
+++ b/src/main/java/com/workhub/global/error/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     FORBIDDEN_POST_UPDATE(HttpStatus.FORBIDDEN, "PO-004", "게시글 수정 권한이 없습니다."),
     FORBIDDEN_POST_DELETE(HttpStatus.FORBIDDEN, "PO-005", "게시글 삭제 권한이 없습니다."),
     NOT_MATCHED_PROJECT_POST(HttpStatus.BAD_REQUEST, "PO-006", "잘못된 프로젝트 또는 단계의 게시글입니다."),
+    INVALID_PROJECT_STATUS_FOR_POST(HttpStatus.BAD_REQUEST, "C-0011", "진행중인 프로젝트에서만 게시글을 처리할 수 있습니다."),
 
 
     // CS 게시판

--- a/src/main/java/com/workhub/global/error/ErrorCode.java
+++ b/src/main/java/com/workhub/global/error/ErrorCode.java
@@ -43,6 +43,9 @@ public enum ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "PO-001", "게시물을 찾을 수 없습니다."),
     PARENT_POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "PO-002", "부모 게시글을 찾을 수 없습니다."),
     ALREADY_DELETED_POST(HttpStatus.BAD_REQUEST, "PO-003", "이미 삭제된 게시글입니다."),
+    FORBIDDEN_POST_UPDATE(HttpStatus.FORBIDDEN, "PO-004", "게시글 수정 권한이 없습니다."),
+    FORBIDDEN_POST_DELETE(HttpStatus.FORBIDDEN, "PO-005", "게시글 삭제 권한이 없습니다."),
+    NOT_MATCHED_PROJECT_POST(HttpStatus.BAD_REQUEST, "PO-006", "잘못된 프로젝트 또는 단계의 게시글입니다."),
 
 
     // CS 게시판

--- a/src/main/java/com/workhub/post/api/PostApi.java
+++ b/src/main/java/com/workhub/post/api/PostApi.java
@@ -7,6 +7,7 @@ import com.workhub.post.record.request.PostRequest;
 import com.workhub.post.record.request.PostUpdateRequest;
 import com.workhub.post.record.response.PostPageResponse;
 import com.workhub.post.record.response.PostResponse;
+import com.workhub.userTable.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -21,6 +22,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "게시물 관리", description = "프로젝트 단계별 게시물 CRUD API")
@@ -49,7 +51,8 @@ public interface PostApi {
     ResponseEntity<ApiResponse<PostResponse>> createPost(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
-            @Valid @RequestBody PostRequest request
+            @Valid @RequestBody PostRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
     @Operation(
@@ -80,7 +83,8 @@ public interface PostApi {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) PostType postType,
             @RequestParam(required = false) HashTag hashTag,
-            @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
     @Operation(
@@ -106,7 +110,8 @@ public interface PostApi {
     ResponseEntity<ApiResponse<PostResponse>> getPost(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
-            @PathVariable Long postId
+            @PathVariable Long postId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
     // PATCH 요청으로 제목/내용/분류/해시태그/IP를 수정
@@ -135,7 +140,8 @@ public interface PostApi {
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
             @PathVariable Long postId,
-            @Valid @RequestBody PostUpdateRequest request
+            @Valid @RequestBody PostUpdateRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
     @Operation(
@@ -161,7 +167,8 @@ public interface PostApi {
     ResponseEntity<ApiResponse<Object>> deletePost(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
-            @PathVariable Long postId
+            @PathVariable Long postId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
 }

--- a/src/main/java/com/workhub/post/controller/PostController.java
+++ b/src/main/java/com/workhub/post/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.workhub.post.controller;
 
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.response.ApiResponse;
 import com.workhub.post.api.PostApi;
 import com.workhub.post.entity.HashTag;
@@ -10,7 +12,11 @@ import com.workhub.post.record.request.PostUpdateRequest;
 import com.workhub.post.record.response.PostPageResponse;
 import com.workhub.post.record.response.PostResponse;
 import com.workhub.post.record.response.PostSummaryResponse;
-import com.workhub.post.service.PostService;
+import com.workhub.post.service.CreatePostService;
+import com.workhub.post.service.DeletePostService;
+import com.workhub.post.service.ReadPostService;
+import com.workhub.post.service.UpdatePostService;
+import com.workhub.userTable.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +25,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,7 +34,10 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/projects/{projectId}/nodes/{nodeId}/posts")
 public class PostController implements PostApi {
-    private final PostService postService;
+    private final CreatePostService createPostService;
+    private final ReadPostService readPostService;
+    private final UpdatePostService updatePostService;
+    private final DeletePostService deletePostService;
 
     /**
      * 프로젝트/노드별 게시글을 생성한다.
@@ -43,8 +53,9 @@ public class PostController implements PostApi {
     public ResponseEntity<ApiResponse<PostResponse>> createPost(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
-            @Valid @RequestBody PostRequest request) {
-        Post created = postService.create(request);
+            @Valid @RequestBody PostRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Post created = createPostService.create(projectId, nodeId, getUserId(userDetails), request);
         return ApiResponse.created(PostResponse.from(created), "게시글이 생성되었습니다.");
     }
 
@@ -64,12 +75,13 @@ public class PostController implements PostApi {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) PostType postType,
             @RequestParam(required = false) HashTag hashTag,
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         /**
          * 검색 조건과 Pageable 정보를 기반으로 게시글 목록을 조회한다.
          */
-        Page<Post> page = postService.search(nodeId, keyword, postType, hashTag, pageable);
+        Page<Post> page = readPostService.search(projectId, nodeId, getUserId(userDetails), keyword, postType, hashTag, pageable);
         List<PostSummaryResponse> posts = page.getContent()
                 .stream()
                 .map(PostSummaryResponse::from)
@@ -87,8 +99,9 @@ public class PostController implements PostApi {
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostResponse>> getPost(@PathVariable Long projectId,
                                                              @PathVariable Long nodeId,
-                                                             @PathVariable Long postId) {
-        PostResponse response = PostResponse.from(postService.findById(postId));
+                                                             @PathVariable Long postId,
+                                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PostResponse response = PostResponse.from(readPostService.findById(projectId, nodeId, getUserId(userDetails), postId));
         return ApiResponse.success(response, "게시글 조회에 성공했습니다.");
     }
 
@@ -101,9 +114,9 @@ public class PostController implements PostApi {
     public ResponseEntity<ApiResponse<PostResponse>> updatePost(@PathVariable Long projectId,
                                                                 @PathVariable Long nodeId,
                                                                 @PathVariable Long postId,
-                                                                @Valid @RequestBody PostUpdateRequest request) {
-        Post target = postService.findById(postId);
-        Post updated = postService.update(target, request);
+                                                                @Valid @RequestBody PostUpdateRequest request,
+                                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Post updated = updatePostService.update(projectId, nodeId, postId, getUserId(userDetails), request);
         return ApiResponse.success(PostResponse.from(updated), "게시물 수정에 성공했습니다.");
     }
 
@@ -120,8 +133,22 @@ public class PostController implements PostApi {
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse<Object>> deletePost(@PathVariable Long projectId,
                                                           @PathVariable Long nodeId,
-                                                          @PathVariable Long postId) {
-        postService.delete(postId);
+                                                          @PathVariable Long postId,
+                                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+        deletePostService.delete(projectId, nodeId, postId, getUserId(userDetails));
         return ApiResponse.success(null, "게시물 삭제에 성공했습니다.");
+    }
+
+    /**
+     * 인증 객체의 사용자 ID를 추출하며, 비로그인 상태는 즉시 차단한다.
+     *
+     * @param userDetails 인증 정보
+     * @return 사용자 ID
+     */
+    private Long getUserId(CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new BusinessException(ErrorCode.NOT_LOGGED_IN);
+        }
+        return userDetails.getUserId();
     }
 }

--- a/src/main/java/com/workhub/post/controller/PostController.java
+++ b/src/main/java/com/workhub/post/controller/PostController.java
@@ -5,13 +5,11 @@ import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.response.ApiResponse;
 import com.workhub.post.api.PostApi;
 import com.workhub.post.entity.HashTag;
-import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostType;
 import com.workhub.post.record.request.PostRequest;
 import com.workhub.post.record.request.PostUpdateRequest;
 import com.workhub.post.record.response.PostPageResponse;
 import com.workhub.post.record.response.PostResponse;
-import com.workhub.post.record.response.PostSummaryResponse;
 import com.workhub.post.service.CreatePostService;
 import com.workhub.post.service.DeletePostService;
 import com.workhub.post.service.ReadPostService;
@@ -21,14 +19,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -55,8 +50,8 @@ public class PostController implements PostApi {
             @PathVariable Long nodeId,
             @Valid @RequestBody PostRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Post created = createPostService.create(projectId, nodeId, getUserId(userDetails), request);
-        return ApiResponse.created(PostResponse.from(created), "게시글이 생성되었습니다.");
+        PostResponse created = createPostService.create(projectId, nodeId, getUserId(userDetails), request);
+        return ApiResponse.created(created, "게시글이 생성되었습니다.");
     }
 
     /**
@@ -81,16 +76,7 @@ public class PostController implements PostApi {
         /**
          * 검색 조건과 Pageable 정보를 기반으로 게시글 목록을 조회한다.
          */
-        Page<Post> page = readPostService.search(projectId, nodeId, getUserId(userDetails), keyword, postType, hashTag, pageable);
-        List<PostSummaryResponse> posts = page.getContent()
-                .stream()
-                .map(PostSummaryResponse::from)
-                .toList();
-
-        /**
-         * 조회 결과를 응답 DTO로 변환한다.
-         */
-        PostPageResponse response = PostPageResponse.of(posts, page);
+        PostPageResponse response = readPostService.search(projectId, nodeId, getUserId(userDetails), keyword, postType, hashTag, pageable);
 
         return ApiResponse.success(response, "게시글 목록 조회에 성공했습니다.");
     }
@@ -101,7 +87,7 @@ public class PostController implements PostApi {
                                                              @PathVariable Long nodeId,
                                                              @PathVariable Long postId,
                                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
-        PostResponse response = PostResponse.from(readPostService.findById(projectId, nodeId, getUserId(userDetails), postId));
+        PostResponse response = readPostService.findById(projectId, nodeId, getUserId(userDetails), postId);
         return ApiResponse.success(response, "게시글 조회에 성공했습니다.");
     }
 
@@ -116,8 +102,8 @@ public class PostController implements PostApi {
                                                                 @PathVariable Long postId,
                                                                 @Valid @RequestBody PostUpdateRequest request,
                                                                 @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Post updated = updatePostService.update(projectId, nodeId, postId, getUserId(userDetails), request);
-        return ApiResponse.success(PostResponse.from(updated), "게시물 수정에 성공했습니다.");
+        PostResponse updated = updatePostService.update(projectId, nodeId, postId, getUserId(userDetails), request);
+        return ApiResponse.success(updated, "게시물 수정에 성공했습니다.");
     }
 
     /**

--- a/src/main/java/com/workhub/post/entity/Post.java
+++ b/src/main/java/com/workhub/post/entity/Post.java
@@ -57,13 +57,15 @@ public class Post extends BaseTimeEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public static Post of(Long parentPostId, PostRequest request) {
+    public static Post of(Long projectNodeId, Long userId, Long parentPostId, PostRequest request) {
         return Post.builder()
                 .type(request.postType())
                 .title(request.title())
                 .content(request.content())
                 .postIp(request.postIp())
                 .hashtag(request.hashTag())
+                .userId(userId)
+                .projectNodeId(projectNodeId)
                 .parentPostId(parentPostId)
                 .build();
     }

--- a/src/main/java/com/workhub/post/service/CreatePostService.java
+++ b/src/main/java/com/workhub/post/service/CreatePostService.java
@@ -4,6 +4,7 @@ import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.post.entity.Post;
 import com.workhub.post.record.request.PostRequest;
+import com.workhub.post.record.response.PostResponse;
 import com.workhub.project.service.ProjectService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +27,12 @@ public class CreatePostService {
      * @param request 게시글 생성 요청
      * @return 저장된 게시글
      */
-    public Post create(Long projectId, Long projectNodeId, Long userId, PostRequest request) {
+    public PostResponse create(Long projectId, Long projectNodeId, Long userId, PostRequest request) {
         projectService.validateCompletedProject(projectId);
         Long parentPostId = request.parentPostId();
         if (parentPostId != null && !postService.existsActivePost(parentPostId)) {
             throw new BusinessException(ErrorCode.PARENT_POST_NOT_FOUND);
         }
-        return postService.save(Post.of(projectNodeId, userId, parentPostId, request));
+        return PostResponse.from(postService.save(Post.of(projectNodeId, userId, parentPostId, request)));
     }
 }

--- a/src/main/java/com/workhub/post/service/CreatePostService.java
+++ b/src/main/java/com/workhub/post/service/CreatePostService.java
@@ -28,7 +28,7 @@ public class CreatePostService {
      * @return 저장된 게시글
      */
     public PostResponse create(Long projectId, Long projectNodeId, Long userId, PostRequest request) {
-        projectService.validateCompletedProject(projectId);
+        projectService.validateProject(projectId);
         Long parentPostId = request.parentPostId();
         if (parentPostId != null && !postService.existsActivePost(parentPostId)) {
             throw new BusinessException(ErrorCode.PARENT_POST_NOT_FOUND);

--- a/src/main/java/com/workhub/post/service/CreatePostService.java
+++ b/src/main/java/com/workhub/post/service/CreatePostService.java
@@ -1,0 +1,37 @@
+package com.workhub.post.service;
+
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.post.entity.Post;
+import com.workhub.post.record.request.PostRequest;
+import com.workhub.project.service.ProjectService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreatePostService {
+
+    private final PostService postService;
+    private final ProjectService projectService;
+
+    /**
+     * 게시글 생성 시 프로젝트 상태와 부모 게시글 유효성을 검증한 뒤 저장한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param projectNodeId 프로젝트 노드 ID
+     * @param userId 작성자 ID
+     * @param request 게시글 생성 요청
+     * @return 저장된 게시글
+     */
+    public Post create(Long projectId, Long projectNodeId, Long userId, PostRequest request) {
+        projectService.validateCompletedProject(projectId);
+        Long parentPostId = request.parentPostId();
+        if (parentPostId != null && !postService.existsActivePost(parentPostId)) {
+            throw new BusinessException(ErrorCode.PARENT_POST_NOT_FOUND);
+        }
+        return postService.save(Post.of(projectNodeId, userId, parentPostId, request));
+    }
+}

--- a/src/main/java/com/workhub/post/service/DeletePostService.java
+++ b/src/main/java/com/workhub/post/service/DeletePostService.java
@@ -1,0 +1,39 @@
+package com.workhub.post.service;
+
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.post.entity.Post;
+import com.workhub.project.service.ProjectService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeletePostService {
+
+    private final PostService postService;
+    private final ProjectService projectService;
+
+    /**
+     * 게시글 삭제 시 프로젝트/노드 검증과 작성자 권한을 체크한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param nodeId 노드 ID
+     * @param postId 게시글 ID
+     * @param userId 요청자 ID
+     */
+    public void delete(Long projectId, Long nodeId, Long postId, Long userId) {
+        projectService.validateCompletedProject(projectId);
+        Post target = postService.findById(postId);
+        postService.validateNode(target, nodeId);
+        if (target.isDeleted()) {
+            throw new BusinessException(ErrorCode.ALREADY_DELETED_POST);
+        }
+        if (!target.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_POST_DELETE);
+        }
+        target.markDeleted();
+    }
+}

--- a/src/main/java/com/workhub/post/service/DeletePostService.java
+++ b/src/main/java/com/workhub/post/service/DeletePostService.java
@@ -25,7 +25,7 @@ public class DeletePostService {
      * @param userId 요청자 ID
      */
     public void delete(Long projectId, Long nodeId, Long postId, Long userId) {
-        projectService.validateCompletedProject(projectId);
+        projectService.validateProject(projectId);
         Post target = postService.findById(postId);
         postService.validateNode(target, nodeId);
         if (target.isDeleted()) {

--- a/src/main/java/com/workhub/post/service/ReadPostService.java
+++ b/src/main/java/com/workhub/post/service/ReadPostService.java
@@ -5,12 +5,17 @@ import com.workhub.global.error.exception.BusinessException;
 import com.workhub.post.entity.HashTag;
 import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostType;
+import com.workhub.post.record.response.PostPageResponse;
+import com.workhub.post.record.response.PostResponse;
+import com.workhub.post.record.response.PostSummaryResponse;
 import com.workhub.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,12 +34,12 @@ public class ReadPostService {
      * @param postId 게시글 ID
      * @return 조회된 게시글
      */
-    public Post findById(Long projectId, Long nodeId, Long userId, Long postId) {
+    public PostResponse findById(Long projectId, Long nodeId, Long userId, Long postId) {
         ensureAuthenticated(userId);
         projectService.validateCompletedProject(projectId);
         Post post = postService.findById(postId);
         postService.validateNode(post, nodeId);
-        return post;
+        return PostResponse.from(post);
     }
 
     /**
@@ -49,16 +54,20 @@ public class ReadPostService {
      * @param pageable 페이징 정보
      * @return 검색 결과 페이지
      */
-    public Page<Post> search(Long projectId,
-                             Long nodeId,
-                             Long userId,
-                             String keyword,
-                             PostType postType,
-                             HashTag hashTag,
-                             Pageable pageable) {
+    public PostPageResponse search(Long projectId,
+                                   Long nodeId,
+                                   Long userId,
+                                   String keyword,
+                                   PostType postType,
+                                   HashTag hashTag,
+                                   Pageable pageable) {
         ensureAuthenticated(userId);
         projectService.validateCompletedProject(projectId);
-        return postService.search(nodeId, keyword, postType, hashTag, pageable);
+        Page<Post> page = postService.search(nodeId, keyword, postType, hashTag, pageable);
+        List<PostSummaryResponse> posts = page.getContent().stream()
+                .map(PostSummaryResponse::from)
+                .toList();
+        return PostPageResponse.of(posts, page);
     }
 
     /**

--- a/src/main/java/com/workhub/post/service/ReadPostService.java
+++ b/src/main/java/com/workhub/post/service/ReadPostService.java
@@ -36,7 +36,7 @@ public class ReadPostService {
      */
     public PostResponse findById(Long projectId, Long nodeId, Long userId, Long postId) {
         ensureAuthenticated(userId);
-        projectService.validateCompletedProject(projectId);
+        projectService.validateProject(projectId);
         Post post = postService.findById(postId);
         postService.validateNode(post, nodeId);
         return PostResponse.from(post);
@@ -62,7 +62,7 @@ public class ReadPostService {
                                    HashTag hashTag,
                                    Pageable pageable) {
         ensureAuthenticated(userId);
-        projectService.validateCompletedProject(projectId);
+        projectService.validateProject(projectId);
         Page<Post> page = postService.search(nodeId, keyword, postType, hashTag, pageable);
         List<PostSummaryResponse> posts = page.getContent().stream()
                 .map(PostSummaryResponse::from)

--- a/src/main/java/com/workhub/post/service/ReadPostService.java
+++ b/src/main/java/com/workhub/post/service/ReadPostService.java
@@ -1,0 +1,74 @@
+package com.workhub.post.service;
+
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.post.entity.HashTag;
+import com.workhub.post.entity.Post;
+import com.workhub.post.entity.PostType;
+import com.workhub.project.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadPostService {
+
+    private final PostService postService;
+    private final ProjectService projectService;
+
+    /**
+     * 프로젝트/노드 범위 내 게시글을 단건 조회한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param nodeId 노드 ID
+     * @param userId 인증 사용자 ID
+     * @param postId 게시글 ID
+     * @return 조회된 게시글
+     */
+    public Post findById(Long projectId, Long nodeId, Long userId, Long postId) {
+        ensureAuthenticated(userId);
+        projectService.validateCompletedProject(projectId);
+        Post post = postService.findById(postId);
+        postService.validateNode(post, nodeId);
+        return post;
+    }
+
+    /**
+     * 프로젝트/노드 범위 내 게시글 목록을 검색한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param nodeId 노드 ID
+     * @param userId 인증 사용자 ID
+     * @param keyword 검색 키워드
+     * @param postType 게시글 타입
+     * @param hashTag 해시태그 필터
+     * @param pageable 페이징 정보
+     * @return 검색 결과 페이지
+     */
+    public Page<Post> search(Long projectId,
+                             Long nodeId,
+                             Long userId,
+                             String keyword,
+                             PostType postType,
+                             HashTag hashTag,
+                             Pageable pageable) {
+        ensureAuthenticated(userId);
+        projectService.validateCompletedProject(projectId);
+        return postService.search(nodeId, keyword, postType, hashTag, pageable);
+    }
+
+    /**
+     * 인증되지 않은 요청을 선제적으로 차단한다.
+     *
+     * @param userId 인증 사용자 ID
+     */
+    private void ensureAuthenticated(Long userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.NOT_LOGGED_IN);
+        }
+    }
+}

--- a/src/main/java/com/workhub/post/service/UpdatePostService.java
+++ b/src/main/java/com/workhub/post/service/UpdatePostService.java
@@ -4,6 +4,7 @@ import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.post.entity.Post;
 import com.workhub.post.record.request.PostUpdateRequest;
+import com.workhub.post.record.response.PostResponse;
 import com.workhub.project.service.ProjectService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class UpdatePostService {
      * @param request 수정 요청
      * @return 수정된 게시글
      */
-    public Post update(Long projectId, Long nodeId, Long postId, Long userId, PostUpdateRequest request) {
+    public PostResponse update(Long projectId, Long nodeId, Long postId, Long userId, PostUpdateRequest request) {
         projectService.validateCompletedProject(projectId);
         Post target = postService.findById(postId);
         postService.validateNode(target, nodeId);
@@ -35,6 +36,6 @@ public class UpdatePostService {
             throw new BusinessException(ErrorCode.FORBIDDEN_POST_UPDATE);
         }
         target.update(request);
-        return target;
+        return PostResponse.from(target);
     }
 }

--- a/src/main/java/com/workhub/post/service/UpdatePostService.java
+++ b/src/main/java/com/workhub/post/service/UpdatePostService.java
@@ -1,0 +1,40 @@
+package com.workhub.post.service;
+
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.post.entity.Post;
+import com.workhub.post.record.request.PostUpdateRequest;
+import com.workhub.project.service.ProjectService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdatePostService {
+
+    private final PostService postService;
+    private final ProjectService projectService;
+
+    /**
+     * 프로젝트와 노드 일치 여부, 작성자 권한을 검증한 뒤 게시글을 수정한다.
+     *
+     * @param projectId 프로젝트 ID
+     * @param nodeId 노드 ID
+     * @param postId 게시글 ID
+     * @param userId 요청자 ID
+     * @param request 수정 요청
+     * @return 수정된 게시글
+     */
+    public Post update(Long projectId, Long nodeId, Long postId, Long userId, PostUpdateRequest request) {
+        projectService.validateCompletedProject(projectId);
+        Post target = postService.findById(postId);
+        postService.validateNode(target, nodeId);
+        if (!target.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_POST_UPDATE);
+        }
+        target.update(request);
+        return target;
+    }
+}

--- a/src/main/java/com/workhub/post/service/UpdatePostService.java
+++ b/src/main/java/com/workhub/post/service/UpdatePostService.java
@@ -29,7 +29,7 @@ public class UpdatePostService {
      * @return 수정된 게시글
      */
     public PostResponse update(Long projectId, Long nodeId, Long postId, Long userId, PostUpdateRequest request) {
-        projectService.validateCompletedProject(projectId);
+        projectService.validateProject(projectId);
         Post target = postService.findById(postId);
         postService.validateNode(target, nodeId);
         if (!target.getUserId().equals(userId)) {

--- a/src/main/java/com/workhub/project/service/ProjectService.java
+++ b/src/main/java/com/workhub/project/service/ProjectService.java
@@ -87,4 +87,11 @@ public class ProjectService {
         }
         return project;
     }
+    public Project validateProject(Long projectId) {
+        Project project = findProjectById(projectId);
+        if (!Status.IN_PROGRESS.equals(project.getStatus())) {
+            throw new BusinessException(ErrorCode.INVALID_PROJECT_STATUS_FOR_POST);
+        }
+        return project;
+    }
 }

--- a/src/test/java/com/workhub/post/service/PostServiceTest.java
+++ b/src/test/java/com/workhub/post/service/PostServiceTest.java
@@ -8,6 +8,10 @@ import com.workhub.post.entity.PostType;
 import com.workhub.post.record.request.PostRequest;
 import com.workhub.post.record.request.PostUpdateRequest;
 import com.workhub.post.repository.PostRepository;
+import com.workhub.project.entity.Project;
+import com.workhub.project.entity.Status;
+import com.workhub.project.service.ProjectService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +32,19 @@ public class PostServiceTest {
     PostRepository postRepository;
     @InjectMocks
     PostService postService;
+    @Mock
+    ProjectService projectService;
+
+    CreatePostService createPostService;
+    UpdatePostService updatePostService;
+    DeletePostService deletePostService;
+
+    @BeforeEach
+    void setUp() {
+        createPostService = new CreatePostService(postService, projectService);
+        updatePostService = new UpdatePostService(postService, projectService);
+        deletePostService = new DeletePostService(postService, projectService);
+    }
 
     @Test
     @DisplayName("부모 게시물이 없으면 예외를 던진다.")
@@ -36,9 +53,9 @@ public class PostServiceTest {
                 "title", PostType.NOTICE, "content", "11.1.1",1L, HashTag.DESIGN
         );
         given(postRepository.existsByPostIdAndDeletedAtIsNull(1L)).willReturn(false);
-        given(postRepository.existsByPostIdIncludingDeleted(1L)).willReturn(false);
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
 
-        assertThatThrownBy(() -> postService.create(request))
+        assertThatThrownBy(() -> createPostService.create(10L, 20L, 30L, request))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARENT_POST_NOT_FOUND);
     }
@@ -50,9 +67,9 @@ public class PostServiceTest {
                 "title", PostType.NOTICE, "content", "11.1.1",1L, HashTag.DESIGN
         );
         given(postRepository.existsByPostIdAndDeletedAtIsNull(1L)).willReturn(false);
-        given(postRepository.existsByPostIdIncludingDeleted(1L)).willReturn(true);
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
 
-        assertThatThrownBy(() -> postService.create(request))
+        assertThatThrownBy(() -> createPostService.create(10L, 20L, 30L, request))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARENT_POST_NOT_FOUND);
     }
@@ -69,12 +86,13 @@ public class PostServiceTest {
                 .hashtag(HashTag.DESIGN)
                 .build();
         given(postRepository.save(any(Post.class))).willReturn(saved);
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
 
         PostRequest request = new PostRequest(
                 "title", PostType.NOTICE, "content", "127.0.0.1", null, HashTag.DESIGN
         );
 
-        Post result = postService.create(request);
+        Post result = createPostService.create(10L, 20L, 30L, request);
 
         assertThat(result.getPostId()).isEqualTo(10L);
         assertThat(result.getTitle()).isEqualTo("title");
@@ -90,16 +108,47 @@ public class PostServiceTest {
                 .type(PostType.GENERAL)
                 .postIp("1.1.1.1")
                 .hashtag(HashTag.REQ_DEF)
+                .projectNodeId(20L)
+                .userId(30L)
                 .build();
 
         PostUpdateRequest request = new PostUpdateRequest(
                 "new", PostType.NOTICE, "new content", "2.2.2.2", HashTag.DESIGN
         );
 
-        Post result = postService.update(origin, request);
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(origin));
+
+        Post result = updatePostService.update(10L, 20L, 1L, 30L, request);
 
         assertThat(result.getTitle()).isEqualTo("new");
         assertThat(result.getPostIp()).isEqualTo("2.2.2.2");
+    }
+
+    @Test
+    @DisplayName("작성자가 아니면 게시글을 수정할 수 없다")
+    void update_withDifferentUser_shouldThrow() {
+        Post origin = Post.builder()
+                .postId(1L)
+                .title("old")
+                .content("old")
+                .type(PostType.GENERAL)
+                .postIp("1.1.1.1")
+                .hashtag(HashTag.REQ_DEF)
+                .projectNodeId(20L)
+                .userId(30L)
+                .build();
+
+        PostUpdateRequest request = new PostUpdateRequest(
+                "new", PostType.NOTICE, "new content", "2.2.2.2", HashTag.DESIGN
+        );
+
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(origin));
+
+        assertThatThrownBy(() -> updatePostService.update(10L, 20L, 1L, 99L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_POST_UPDATE);
     }
 
     @Test
@@ -115,9 +164,10 @@ public class PostServiceTest {
     @Test
     @DisplayName("삭제 대상 게시글이 없으면 예외를 던진다")
     void delete_withPostNotFound_shouldThrow() {
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(99L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> postService.delete(99L))
+        assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 99L, 30L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_NOT_FOUND);
     }
@@ -125,11 +175,22 @@ public class PostServiceTest {
     @Test
     @DisplayName("이미 삭제된 게시글을 삭제하려 하면 예외를 던진다")
     void delete_withAlreadyDeletedPost_shouldThrow() {
-        given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.empty());
+        Post deleted = Post.builder()
+                .postId(1L)
+                .type(PostType.NOTICE)
+                .title("title")
+                .content("content")
+                .hashtag(HashTag.DESIGN)
+                .projectNodeId(20L)
+                .userId(30L)
+                .build();
+        deleted.markDeleted();
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(deleted));
 
-        assertThatThrownBy(() -> postService.delete(1L))
+        assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 1L, 30L))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.POST_NOT_FOUND);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_DELETED_POST);
     }
 
     @Test
@@ -140,14 +201,42 @@ public class PostServiceTest {
                 .title("title")
                 .content("content")
                 .type(PostType.NOTICE)
+                .projectNodeId(20L)
+                .userId(30L)
                 .build();
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(existing));
 
-        postService.delete(1L);
+        deletePostService.delete(10L, 20L, 1L, 30L);
 
         assertThat(existing.isDeleted()).isTrue();
     }
 
+    @Test
+    @DisplayName("작성자가 아니면 게시글을 삭제할 수 없다")
+    void delete_withDifferentUser_shouldThrowForbidden() {
+        Post existing = Post.builder()
+                .postId(1L)
+                .title("title")
+                .content("content")
+                .type(PostType.NOTICE)
+                .projectNodeId(20L)
+                .userId(30L)
+                .build();
 
+        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(existing));
 
+        assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 1L, 99L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_POST_DELETE);
+    }
+
+    private Project mockProject(Long projectId) {
+        return Project.builder()
+                .projectId(projectId)
+                .projectTitle("project")
+                .status(Status.COMPLETED)
+                .build();
+    }
 }

--- a/src/test/java/com/workhub/post/service/PostServiceTest.java
+++ b/src/test/java/com/workhub/post/service/PostServiceTest.java
@@ -54,7 +54,7 @@ public class PostServiceTest {
                 "title", PostType.NOTICE, "content", "11.1.1",1L, HashTag.DESIGN
         );
         given(postRepository.existsByPostIdAndDeletedAtIsNull(1L)).willReturn(false);
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
 
         assertThatThrownBy(() -> createPostService.create(10L, 20L, 30L, request))
                 .isInstanceOf(BusinessException.class)
@@ -68,7 +68,7 @@ public class PostServiceTest {
                 "title", PostType.NOTICE, "content", "11.1.1",1L, HashTag.DESIGN
         );
         given(postRepository.existsByPostIdAndDeletedAtIsNull(1L)).willReturn(false);
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
 
         assertThatThrownBy(() -> createPostService.create(10L, 20L, 30L, request))
                 .isInstanceOf(BusinessException.class)
@@ -87,7 +87,7 @@ public class PostServiceTest {
                 .hashtag(HashTag.DESIGN)
                 .build();
         given(postRepository.save(any(Post.class))).willReturn(saved);
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
 
         PostRequest request = new PostRequest(
                 "title", PostType.NOTICE, "content", "127.0.0.1", null, HashTag.DESIGN
@@ -97,6 +97,19 @@ public class PostServiceTest {
 
         assertThat(result.postId()).isEqualTo(10L);
         assertThat(result.title()).isEqualTo("title");
+    }
+
+    @Test
+    @DisplayName("프로젝트 상태가 유효하지 않으면 게시글을 생성할 수 없다")
+    void create_withInvalidProjectStatus_shouldThrow() {
+        PostRequest request = new PostRequest(
+                "title", PostType.NOTICE, "content", "127.0.0.1", null, HashTag.DESIGN
+        );
+        given(projectService.validateProject(10L)).willThrow(new BusinessException(ErrorCode.INVALID_PROJECT_STATUS_FOR_POST));
+
+        assertThatThrownBy(() -> createPostService.create(10L, 20L, 30L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PROJECT_STATUS_FOR_POST);
     }
 
     @Test
@@ -117,7 +130,7 @@ public class PostServiceTest {
                 "new", PostType.NOTICE, "new content", "2.2.2.2", HashTag.DESIGN
         );
 
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(origin));
 
         PostResponse result = updatePostService.update(10L, 20L, 1L, 30L, request);
@@ -144,12 +157,25 @@ public class PostServiceTest {
                 "new", PostType.NOTICE, "new content", "2.2.2.2", HashTag.DESIGN
         );
 
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(origin));
 
         assertThatThrownBy(() -> updatePostService.update(10L, 20L, 1L, 99L, request))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_POST_UPDATE);
+    }
+
+    @Test
+    @DisplayName("프로젝트 상태가 유효하지 않으면 게시글을 수정할 수 없다")
+    void update_withInvalidProjectStatus_shouldThrow() {
+        PostUpdateRequest request = new PostUpdateRequest(
+                "new", PostType.NOTICE, "new content", "2.2.2.2", HashTag.DESIGN
+        );
+        given(projectService.validateProject(10L)).willThrow(new BusinessException(ErrorCode.INVALID_PROJECT_STATUS_FOR_POST));
+
+        assertThatThrownBy(() -> updatePostService.update(10L, 20L, 1L, 30L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PROJECT_STATUS_FOR_POST);
     }
 
     @Test
@@ -165,7 +191,7 @@ public class PostServiceTest {
     @Test
     @DisplayName("삭제 대상 게시글이 없으면 예외를 던진다")
     void delete_withPostNotFound_shouldThrow() {
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(99L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 99L, 30L))
@@ -186,7 +212,7 @@ public class PostServiceTest {
                 .userId(30L)
                 .build();
         deleted.markDeleted();
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(deleted));
 
         assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 1L, 30L))
@@ -205,7 +231,7 @@ public class PostServiceTest {
                 .projectNodeId(20L)
                 .userId(30L)
                 .build();
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(existing));
 
         deletePostService.delete(10L, 20L, 1L, 30L);
@@ -225,7 +251,7 @@ public class PostServiceTest {
                 .userId(30L)
                 .build();
 
-        given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
+        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(existing));
 
         assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 1L, 99L))
@@ -233,11 +259,21 @@ public class PostServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_POST_DELETE);
     }
 
+    @Test
+    @DisplayName("프로젝트 상태가 유효하지 않으면 게시글을 삭제할 수 없다")
+    void delete_withInvalidProjectStatus_shouldThrow() {
+        given(projectService.validateProject(10L)).willThrow(new BusinessException(ErrorCode.INVALID_PROJECT_STATUS_FOR_POST));
+
+        assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 1L, 30L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PROJECT_STATUS_FOR_POST);
+    }
+
     private Project mockProject(Long projectId) {
         return Project.builder()
                 .projectId(projectId)
                 .projectTitle("project")
-                .status(Status.COMPLETED)
+                .status(Status.IN_PROGRESS)
                 .build();
     }
 }

--- a/src/test/java/com/workhub/post/service/PostServiceTest.java
+++ b/src/test/java/com/workhub/post/service/PostServiceTest.java
@@ -7,6 +7,7 @@ import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostType;
 import com.workhub.post.record.request.PostRequest;
 import com.workhub.post.record.request.PostUpdateRequest;
+import com.workhub.post.record.response.PostResponse;
 import com.workhub.post.repository.PostRepository;
 import com.workhub.project.entity.Project;
 import com.workhub.project.entity.Status;
@@ -92,10 +93,10 @@ public class PostServiceTest {
                 "title", PostType.NOTICE, "content", "127.0.0.1", null, HashTag.DESIGN
         );
 
-        Post result = createPostService.create(10L, 20L, 30L, request);
+        PostResponse result = createPostService.create(10L, 20L, 30L, request);
 
-        assertThat(result.getPostId()).isEqualTo(10L);
-        assertThat(result.getTitle()).isEqualTo("title");
+        assertThat(result.postId()).isEqualTo(10L);
+        assertThat(result.title()).isEqualTo("title");
     }
 
     @Test
@@ -119,10 +120,10 @@ public class PostServiceTest {
         given(projectService.validateCompletedProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(origin));
 
-        Post result = updatePostService.update(10L, 20L, 1L, 30L, request);
+        PostResponse result = updatePostService.update(10L, 20L, 1L, 30L, request);
 
-        assertThat(result.getTitle()).isEqualTo("new");
-        assertThat(result.getPostIp()).isEqualTo("2.2.2.2");
+        assertThat(result.title()).isEqualTo("new");
+        assertThat(result.postIp()).isEqualTo("2.2.2.2");
     }
 
     @Test


### PR DESCRIPTION
 ## PR 요약

  > 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

  - [x] 기능 추가
  - [x] 코드 리팩토링
  - [ ] 버그 수정
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 주요 변경 사항

  - post/controller/PostController: 모든 CRUD 엔드포인트에 인증 사용자 ID를 강제하고, 프로젝트/노드 정보와 함께 서비스로 전달하도록 변경했습니다.
  - post/service/*: CRUD 책임을 세분화하고 ProjectService.validateCompletedProject, PostService.validateNode를 통해 상태·노드·작성자 검증을 공통 적용했습니다.
  - post/entity/Post: 게시글 생성 시 작성자/노드 정보를 함께 저장하도록 팩토리 메서드를 확장했습니다.
  - global/error/ErrorCode: 게시글 전용 권한/프로젝트 불일치 오류 코드를 추가했습니다.
  - post/service/PostServiceTest: 새로운 서비스 시그니처와 권한 검증 로직을 검증하는 단위 테스트를 보강했습니다.

  ———

  ## 체크리스트

  ### 코드 품질

  - [x] 코드가 정상적으로 빌드됩니다.
  - [x] 로컬 테스트를 통과했습니다. 
  - [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
  - [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

  ### 기능 검증

  - [x] 주요 기능(화면, API, 로직)이 정상 동작합니다. (인증/검증 로직을 수동 확인)
  - [x] 예외 상황을 고려한 테스트를 진행했습니다. (작성자/프로젝트 검증 단위 테스트 추가)
  - [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다. (해당 없음)

  ### 문서 및 이슈 연동

  - [x] 관련 이슈 번호를 연결했습니다.
  - [ ] 변경된 부분을 README 또는 문서에 반영했습니다.

  ———

  ## 참고 사항

  - Swagger에서 Post API를 호출하려면 인증 토큰(또는 세션)을 먼저 발급받아 Authorize에 입력해야 합니다. 미인증 상태에서는 NOT_LOGGED_IN 오류가 반환됩니다.

  ———

  ## 리뷰어 체크리스트

  - [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
  - [ ] 테스트 커버리지가 충분합니다.
  - [ ] PR 제목과 내용이 일관됩니다.
  - [ ] 커밋 메시지가 명확합니다.
