### PR TITLE
feat : querydsl config, CS POST LIST 기능 (#10)

### DIFF
--- a/src/main/java/com/workhub/cs/api/CsPostApi.java
+++ b/src/main/java/com/workhub/cs/api/CsPostApi.java
@@ -2,6 +2,7 @@ package com.workhub.cs.api;
 
 import com.workhub.cs.dto.CsPostRequest;
 import com.workhub.cs.dto.CsPostResponse;
+import com.workhub.cs.dto.CsPostSearchRequest;
 import com.workhub.cs.dto.CsPostUpdateRequest;
 import com.workhub.cs.entity.CsPostStatus;
 import com.workhub.global.response.ApiResponse;
@@ -14,6 +15,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -50,6 +56,31 @@ public interface CsPostApi {
     ResponseEntity<ApiResponse<CsPostResponse>> findCsPost(
             @PathVariable Long projectId,
             @PathVariable Long csPostId
+    );
+
+    @Operation(
+            summary = "CS 게시글 목록 조회",
+            description = "프로젝트의 모든 CS 게시글을 검색 조건과 페이징 정보로 조회합니다.",
+            parameters = {
+                    @Parameter(name = "projectId", description = "프로젝트 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "searchValue", description = "제목/내용 검색 키워드", in = ParameterIn.QUERY),
+                    @Parameter(name = "csPostStatus", description = "CS 게시글 상태 필터", in = ParameterIn.QUERY)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "CS 게시글 목록 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CsPostResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<Page<CsPostResponse>>> findCsPosts(
+            @PathVariable Long projectId,
+            @ParameterObject CsPostSearchRequest csPostSearchRequest,
+            @ParameterObject @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     );
 
     @Operation(

--- a/src/main/java/com/workhub/cs/controller/CsPostController.java
+++ b/src/main/java/com/workhub/cs/controller/CsPostController.java
@@ -52,7 +52,7 @@ public class CsPostController implements CsPostApi {
     }
 
     /**
-     * 프로젝트늬 CS 게시글 리스트를 조회한다.
+     * 프로젝트의 CS 게시글 리스트를 조회한다.
      *
      * @param projectId 프로젝트 식별자
      * @param pageable 페이징 정보

--- a/src/main/java/com/workhub/cs/controller/CsPostController.java
+++ b/src/main/java/com/workhub/cs/controller/CsPostController.java
@@ -3,6 +3,7 @@ package com.workhub.cs.controller;
 import com.workhub.cs.api.CsPostApi;
 import com.workhub.cs.dto.CsPostRequest;
 import com.workhub.cs.dto.CsPostResponse;
+import com.workhub.cs.dto.CsPostSearchRequest;
 import com.workhub.cs.dto.CsPostUpdateRequest;
 import com.workhub.cs.entity.CsPostStatus;
 import com.workhub.cs.service.CreateCsPostService;
@@ -13,6 +14,10 @@ import com.workhub.global.response.ApiResponse;
 import com.workhub.userTable.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,7 +47,27 @@ public class CsPostController implements CsPostApi {
             @PathVariable Long csPostId
     ) {
         CsPostResponse response = readCsPostService.findCsPost(projectId, csPostId);
+
         return ApiResponse.success(response, "CS 게시글이 조회되었습니다.");
+    }
+
+    /**
+     * 프로젝트늬 CS 게시글 리스트를 조회한다.
+     *
+     * @param projectId 프로젝트 식별자
+     * @param pageable 페이징 정보
+     * @return CsPostResponse
+     */
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<CsPostResponse>>> findCsPosts(
+            @PathVariable Long projectId,
+            CsPostSearchRequest csPostSearchRequest,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<CsPostResponse> csPosts = readCsPostService.findCsPosts(projectId, csPostSearchRequest, pageable);
+
+        return ApiResponse.success(csPosts ,"CS 게시글 목록이 조회되었습니다.");
     }
 
     /**
@@ -120,6 +145,7 @@ public class CsPostController implements CsPostApi {
             @RequestParam CsPostStatus status
     ) {
         CsPostStatus changed = updateCsPostService.changeStatus(projectId, csPostId, status);
+
         return ApiResponse.success(changed, "CS 게시글 상태가 변경되었습니다.");
     }
 }

--- a/src/main/java/com/workhub/cs/dto/CsPostResponse.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostResponse.java
@@ -15,7 +15,9 @@ public record CsPostResponse(
         String title,
         String content,
         Long userId,
-        List<CsPostFileResponse> files
+        List<CsPostFileResponse> files,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
 
     public static CsPostResponse from(CsPost post, List<CsPostFile> fileList) {
@@ -33,6 +35,21 @@ public record CsPostResponse(
                 .content(post.getContent())
                 .userId(post.getUserId())
                 .files(fileResponses)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
+
+    public static CsPostResponse from(CsPost post) {
+        return CsPostResponse.builder()
+                .csPostId(post.getCsPostId())
+                .deletedAt(post.getDeletedAt())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .userId(post.getUserId())
+                .files(Collections.emptyList()) // 리스트 조회에서는 파일 불러오지 않음
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/workhub/cs/dto/CsPostSearchRequest.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostSearchRequest.java
@@ -1,0 +1,9 @@
+package com.workhub.cs.dto;
+
+import com.workhub.cs.entity.CsPostStatus;
+
+public record CsPostSearchType(
+        String searchValue,
+        CsPostStatus csPostStatus
+) {
+}

--- a/src/main/java/com/workhub/cs/dto/CsPostSearchRequest.java
+++ b/src/main/java/com/workhub/cs/dto/CsPostSearchRequest.java
@@ -1,8 +1,10 @@
 package com.workhub.cs.dto;
 
 import com.workhub.cs.entity.CsPostStatus;
+import lombok.Builder;
 
-public record CsPostSearchType(
+@Builder
+public record CsPostSearchRequest(
         String searchValue,
         CsPostStatus csPostStatus
 ) {

--- a/src/main/java/com/workhub/cs/repository/CsPostRepository.java
+++ b/src/main/java/com/workhub/cs/repository/CsPostRepository.java
@@ -3,5 +3,5 @@ package com.workhub.cs.repository;
 import com.workhub.cs.entity.CsPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CsPostRepository extends JpaRepository<CsPost,Long> {
+public interface CsPostRepository extends JpaRepository<CsPost,Long>, CsPostRepositoryCustom {
 }

--- a/src/main/java/com/workhub/cs/repository/CsPostRepositoryCustom.java
+++ b/src/main/java/com/workhub/cs/repository/CsPostRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.workhub.cs.repository;
+
+public interface CsPostRepositoryCustom {
+}

--- a/src/main/java/com/workhub/cs/repository/CsPostRepositoryCustom.java
+++ b/src/main/java/com/workhub/cs/repository/CsPostRepositoryCustom.java
@@ -1,4 +1,13 @@
 package com.workhub.cs.repository;
 
+import com.workhub.cs.dto.CsPostSearchRequest;
+import com.workhub.cs.entity.CsPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
 public interface CsPostRepositoryCustom {
+
+    Page<CsPost> findCsPosts(CsPostSearchRequest searchType, Pageable pageable);
 }

--- a/src/main/java/com/workhub/cs/repository/CsPostRepositoryImpl.java
+++ b/src/main/java/com/workhub/cs/repository/CsPostRepositoryImpl.java
@@ -1,4 +1,59 @@
 package com.workhub.cs.repository;
 
-public class CsPostRepositoryImpl {
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.workhub.cs.dto.CsPostSearchRequest;
+import com.workhub.cs.entity.CsPost;
+import com.workhub.cs.entity.CsPostStatus;
+import com.workhub.cs.entity.QCsPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CsPostRepositoryImpl implements CsPostRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CsPost> findCsPosts(CsPostSearchRequest searchRequest, Pageable pageable) {
+
+        QCsPost csPost = QCsPost.csPost;
+
+        List<CsPost> result =  queryFactory
+                .selectFrom(csPost)
+                .where(
+                        valueContains(searchRequest.searchValue()),
+                        statusEq(searchRequest.csPostStatus())
+                )
+                .orderBy(csPost.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(csPost.count())
+                .from(csPost)
+                .where(
+                        valueContains(searchRequest.searchValue()),
+                        statusEq(searchRequest.csPostStatus())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(result, pageable, total == null ? 0 : total);
+    }
+
+    private BooleanExpression valueContains(String value) {
+        return (value == null || value.isBlank())
+                ? null
+                : QCsPost.csPost.title.containsIgnoreCase(value)
+                    .or(QCsPost.csPost.content.containsIgnoreCase(value));
+    }
+
+    private BooleanExpression statusEq(CsPostStatus status) {
+        return status == null ? null : QCsPost.csPost.csPostStatus.eq(status);
+    }
 }

--- a/src/main/java/com/workhub/cs/repository/CsPostRepositoryImpl.java
+++ b/src/main/java/com/workhub/cs/repository/CsPostRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.workhub.cs.repository;
+
+public class CsPostRepositoryImpl {
+}

--- a/src/main/java/com/workhub/cs/service/CsPostService.java
+++ b/src/main/java/com/workhub/cs/service/CsPostService.java
@@ -1,5 +1,6 @@
 package com.workhub.cs.service;
 
+import com.workhub.cs.dto.CsPostSearchRequest;
 import com.workhub.cs.entity.CsPost;
 import com.workhub.cs.entity.CsPostFile;
 import com.workhub.cs.repository.CsPostFileRepository;
@@ -8,6 +9,8 @@ import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -54,5 +57,9 @@ public class CsPostService {
      */
     public List<CsPostFile> findFilesByCsPostId(Long csPostId) {
         return csPostFileRepository.findByCsPostId(csPostId);
+    }
+
+    public Page<CsPost> findCsPosts(CsPostSearchRequest searchType, Pageable pageable) {
+        return csPostRepository.findCsPosts(searchType, pageable);
     }
 }

--- a/src/main/java/com/workhub/cs/service/ReadCsPostService.java
+++ b/src/main/java/com/workhub/cs/service/ReadCsPostService.java
@@ -1,12 +1,15 @@
 package com.workhub.cs.service;
 
 import com.workhub.cs.dto.CsPostResponse;
+import com.workhub.cs.dto.CsPostSearchRequest;
 import com.workhub.cs.entity.CsPost;
 import com.workhub.cs.entity.CsPostFile;
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,5 +43,20 @@ public class ReadCsPostService {
                 .toList();
 
         return CsPostResponse.from(csPost, files);
+    }
+
+    /**
+     * CS POST 게시글 리스트를 조회한다.
+     * @param projectId 프로젝트 식별자
+     * @param searchType 검색 옵션
+     * @param pageable 페이징 정보
+     * @return Page<CsPostResponse>
+     */
+    public Page<CsPostResponse> findCsPosts(Long projectId, CsPostSearchRequest searchType, Pageable pageable) {
+
+        projectService.validateCompletedProject(projectId);
+        Page<CsPost> csPosts = csPostService.findCsPosts(searchType, pageable);
+
+        return csPosts.map(CsPostResponse::from);
     }
 }

--- a/src/main/java/com/workhub/global/config/QuerydslConfig.java
+++ b/src/main/java/com/workhub/global/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.bird.cos.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/workhub/global/config/QuerydslConfig.java
+++ b/src/main/java/com/workhub/global/config/QuerydslConfig.java
@@ -1,4 +1,4 @@
-package com.bird.cos.config;
+package com.workhub.global.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/src/main/resources/db/3.init_data.sql
+++ b/src/main/resources/db/3.init_data.sql
@@ -1,0 +1,6 @@
+INSERT INTO user_table (email, password, role)
+VALUES (
+           'admin@workhub.com',
+           '$2a$10$8Hu5yHN6vLbAuh7e1QUQaO86z8nDp3cnYy7E9i8Tlxh2oYdfL4Rfy',  -- password123
+           'ADMIN'
+       );

--- a/src/main/resources/db/3.init_data.sql
+++ b/src/main/resources/db/3.init_data.sql
@@ -1,6 +1,0 @@
-INSERT INTO user_table (email, password, role)
-VALUES (
-           'admin@workhub.com',
-           '$2a$10$8Hu5yHN6vLbAuh7e1QUQaO86z8nDp3cnYy7E9i8Tlxh2oYdfL4Rfy',  -- password123
-           'ADMIN'
-       );


### PR DESCRIPTION
## PR 요약
> Querydsl config, CS POST LIST 조회 및 페이징 처리

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
  - src/main/java/com/workhub/cs/api/CsPostApi.java: findCsPosts 목록 조회 API 스펙을 정의하고 검색 파라미터/페이징 정보를 Swagger 문서에 노출.
  - src/main/java/com/workhub/cs/controller/CsPostController.java: 컨트롤러의 목록 조회 메서드에 @Override를 붙여 CsPostApi 정의와 연결.
  - Querydsl Config 추가

---

## 체크리스트

### 코드 품질
- [x] 코드가 정상적으로 빌드됩니다.
- [x] 로컬 테스트를 통과했습니다.
- [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [ ] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [ ] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [x] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
