### PR TITLE
feature: 답글 역할 구현, 부모 게시물 필터링 및 목록 구현 (#57)

### DIFF
--- a/src/main/java/com/workhub/post/record/response/PostPageResponse.java
+++ b/src/main/java/com/workhub/post/record/response/PostPageResponse.java
@@ -1,17 +1,19 @@
 package com.workhub.post.record.response;
 
+import org.springframework.data.domain.Page;
+
 import java.util.List;
 
 /** 게시글 목록과 페이지 메타데이터를 함께 전달하는 DTO */
 public record PostPageResponse(
-        List<PostSummaryResponse> posts,
+        List<PostThreadResponse> posts,
         long totalElements,
         int totalPages,
         int currentPage,
         int size
 ) {
     /** Page 객체에서 필요한 메타데이터만 추출한다. */
-    public static PostPageResponse of(List<PostSummaryResponse> posts, org.springframework.data.domain.Page<?> page) {
+    public static PostPageResponse of(List<PostThreadResponse> posts, Page<?> page) {
         return new PostPageResponse(
                 posts,
                 page.getTotalElements(),

--- a/src/main/java/com/workhub/post/record/response/PostThreadResponse.java
+++ b/src/main/java/com/workhub/post/record/response/PostThreadResponse.java
@@ -5,32 +5,34 @@ import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostType;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
-/** 게시글 목록에서 필요한 요약 정보를 담는 DTO */
-public record PostSummaryResponse(
+/** 계층형 게시글 응답 DTO */
+public record PostThreadResponse(
         Long postId,
+        Long parentPostId,
         PostType postType,
         HashTag hashTag,
         String title,
         String contentPreview,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        List<PostThreadResponse> replies
 ) {
     private static final int PREVIEW_LENGTH = 120;
 
-    public static PostSummaryResponse from(Post post) {
-        return new PostSummaryResponse(
+    public static PostThreadResponse from(Post post, List<PostThreadResponse> replies) {
+        return new PostThreadResponse(
                 post.getPostId(),
+                post.getParentPostId(),
                 post.getType(),
                 post.getHashtag(),
                 post.getTitle(),
                 buildPreview(post.getContent()),
                 post.getCreatedAt(),
-                post.getUpdatedAt()
+                replies
         );
     }
 
-    /** 본문의 앞부분만 잘라낸 미리보기 문자열을 만든다. */
     private static String buildPreview(String content) {
         if (content == null) {
             return "";

--- a/src/main/java/com/workhub/post/repository/PostRepository.java
+++ b/src/main/java/com/workhub/post/repository/PostRepository.java
@@ -3,14 +3,16 @@ package com.workhub.post.repository;
 import com.workhub.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
     Optional<Post> findByPostIdAndDeletedAtIsNull(Long postId);
     boolean existsByPostIdAndDeletedAtIsNull(Long postId);
-    @Query(value = "SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END FROM post WHERE post_id = :postId", nativeQuery = true)
-    boolean existsByPostIdIncludingDeleted(@Param("postId") Long postId);
+
+    List<Post> findByParentPostIdInAndDeletedAtIsNull(Collection<Long> parentIds);
+
+    List<Post> findByParentPostIdAndDeletedAtIsNull(Long parentPostId);
 }

--- a/src/main/java/com/workhub/post/repository/PostSpecifications.java
+++ b/src/main/java/com/workhub/post/repository/PostSpecifications.java
@@ -38,4 +38,9 @@ public final class PostSpecifications {
     public static Specification<Post> withHashTag(HashTag hashTag) {
         return hashTag == null ? null : (root, query, builder) -> builder.equal(root.get("hashtag"), hashTag);
     }
+
+    /** 부모 게시글(부모 ID가 null)만 필터링한다. */
+    public static Specification<Post> onlyRootPosts() {
+        return (root, query, builder) -> builder.isNull(root.get("parentPostId"));
+    }
 }

--- a/src/main/java/com/workhub/post/service/CreatePostService.java
+++ b/src/main/java/com/workhub/post/service/CreatePostService.java
@@ -32,6 +32,12 @@ public class CreatePostService {
         Long parentPostId = request.parentPostId();
         if (parentPostId != null && !postService.existsActivePost(parentPostId)) {
             throw new BusinessException(ErrorCode.PARENT_POST_NOT_FOUND);
+       } else if (parentPostId != null) {
+            Post parent = postService.findById(parentPostId);
+            postService.validateNode(parent, projectNodeId);
+            if (parent.isDeleted()) {
+                throw new BusinessException(ErrorCode.ALREADY_DELETED_POST);
+            }
         }
         return PostResponse.from(postService.save(Post.of(projectNodeId, userId, parentPostId, request)));
     }

--- a/src/main/java/com/workhub/post/service/DeletePostService.java
+++ b/src/main/java/com/workhub/post/service/DeletePostService.java
@@ -34,6 +34,18 @@ public class DeletePostService {
         if (!target.getUserId().equals(userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN_POST_DELETE);
         }
-        target.markDeleted();
+        deleteRecursively(target);
+    }
+
+    /**
+     * 재귀적으로 게시글을 삭제하여 부모 삭제 시 모든 자식 게시글도 함께 삭제되도록 한다.
+     *
+     * @param post 삭제할 게시글
+     */
+    private void deleteRecursively(Post post) {
+        if (!post.isDeleted()) {
+            post.markDeleted();
+        }
+        postService.findChildren(post.getPostId()).forEach(this::deleteRecursively);
     }
 }

--- a/src/main/java/com/workhub/post/service/PostService.java
+++ b/src/main/java/com/workhub/post/service/PostService.java
@@ -14,40 +14,97 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
 
+    /**
+     * 게시글을 저장한다.
+     *
+     * @param post 저장할 게시글
+     * @return 저장된 게시글
+     */
     @Transactional
     public Post save(Post post) {
         return postRepository.save(post);
     }
 
+    /**
+     * 삭제되지 않은 게시글이 존재하는지 확인한다.
+     *
+     * @param postId 게시글 ID
+     * @return 존재 여부
+     */
     @Transactional(readOnly = true)
     public boolean existsActivePost(Long postId) {
         return postRepository.existsByPostIdAndDeletedAtIsNull(postId);
     }
 
+    /**
+     * 삭제되지 않은 게시글을 조회한다.
+     *
+     * @param id 게시글 ID
+     * @return 게시글 엔티티
+     * @throws BusinessException 게시글이 없을 경우
+     */
     @Transactional(readOnly = true)
     public Post findById(Long id) {
         return postRepository.findByPostIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
     }
 
+    /**
+     * 지정된 노드의 부모 게시글(답글이 아닌 글)만 검색한다.
+     *
+     * @param nodeId 프로젝트 노드 ID
+     * @param keyword 검색 키워드
+     * @param postType 게시글 타입
+     * @param hashTag 해시태그 필터
+     * @param pageable 페이지 정보
+     * @return 검색 결과 페이지
+     */
     @Transactional(readOnly = true)
-    public Page<Post> search(Long nodeId,
-                             String keyword,
-                             PostType postType,
-                             HashTag hashTag,
-                             Pageable pageable) {
-        /** Specification 조합으로 프로젝트/검색 조건을 모두 반영한다. */
+    public Page<Post> searchParentPosts(Long nodeId,
+                                        String keyword,
+                                        PostType postType,
+                                        HashTag hashTag,
+                                        Pageable pageable) {
         Specification<Post> spec = Specification.where(PostSpecifications.withProjectNode(nodeId))
                 .and(PostSpecifications.withKeyword(keyword))
                 .and(PostSpecifications.withPostType(postType))
-                .and(PostSpecifications.withHashTag(hashTag));
+                .and(PostSpecifications.withHashTag(hashTag))
+                .and(PostSpecifications.onlyRootPosts());
 
         return postRepository.findAll(spec, pageable);
+    }
+
+    /**
+     * 여러 부모 게시글에 달린 자식 글을 한 번에 조회한다.
+     *
+     * @param parentIds 부모 게시글 ID 목록
+     * @return 자식 게시글 목록, 없으면 빈 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<Post> findChildren(List<Long> parentIds) {
+        if (parentIds == null || parentIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return postRepository.findByParentPostIdInAndDeletedAtIsNull(parentIds);
+    }
+
+    /**
+     * 단일 부모 게시글에 속한 자식 글 목록을 조회한다.
+     *
+     * @param parentId 부모 게시글 ID
+     * @return 자식 게시글 목록
+     */
+    @Transactional(readOnly = true)
+    public List<Post> findChildren(Long parentId) {
+        return postRepository.findByParentPostIdAndDeletedAtIsNull(parentId);
     }
 
     /**

--- a/src/main/java/com/workhub/post/service/ReadPostService.java
+++ b/src/main/java/com/workhub/post/service/ReadPostService.java
@@ -1,7 +1,5 @@
 package com.workhub.post.service;
 
-import com.workhub.global.error.ErrorCode;
-import com.workhub.global.error.exception.BusinessException;
 import com.workhub.post.entity.HashTag;
 import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostType;
@@ -32,7 +30,6 @@ public class ReadPostService {
      *
      * @param projectId 프로젝트 ID
      * @param nodeId 노드 ID
-     * @param userId 인증 사용자 ID
      * @param postId 게시글 ID
      * @return 조회된 게시글
      */

--- a/src/main/java/com/workhub/post/service/ReadPostService.java
+++ b/src/main/java/com/workhub/post/service/ReadPostService.java
@@ -7,7 +7,7 @@ import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostType;
 import com.workhub.post.record.response.PostPageResponse;
 import com.workhub.post.record.response.PostResponse;
-import com.workhub.post.record.response.PostSummaryResponse;
+import com.workhub.post.record.response.PostThreadResponse;
 import com.workhub.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,7 +15,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +37,6 @@ public class ReadPostService {
      * @return 조회된 게시글
      */
     public PostResponse findById(Long projectId, Long nodeId, Long userId, Long postId) {
-        ensureAuthenticated(userId);
         projectService.validateProject(projectId);
         Post post = postService.findById(postId);
         postService.validateNode(post, nodeId);
@@ -61,23 +62,55 @@ public class ReadPostService {
                                    PostType postType,
                                    HashTag hashTag,
                                    Pageable pageable) {
-        ensureAuthenticated(userId);
         projectService.validateProject(projectId);
-        Page<Post> page = postService.search(nodeId, keyword, postType, hashTag, pageable);
-        List<PostSummaryResponse> posts = page.getContent().stream()
-                .map(PostSummaryResponse::from)
+
+        Page<Post> parentPage = postService.searchParentPosts(nodeId, keyword, postType, hashTag, pageable);
+
+        List<Long> parentIds = parentPage.getContent().stream().map(Post::getPostId).toList();
+        Map<Long, List<Post>> childrenMap = buildChildrenMap(parentIds);
+
+        List<PostThreadResponse> threads = parentPage.getContent().stream()
+                .map(post -> toThreadResponse(post, childrenMap))
                 .toList();
-        return PostPageResponse.of(posts, page);
+
+        return PostPageResponse.of(threads, parentPage);
     }
 
     /**
-     * 인증되지 않은 요청을 선제적으로 차단한다.
+     * 부모-자식 관계를 빠르게 탐색할 수 있도록 부모 ID를 키로 하는 children map을 만든다.
      *
-     * @param userId 인증 사용자 ID
+     * @param rootIds 최상위 게시글 ID 목록
+     * @return 부모 ID -> 자식 게시글 목록 매핑
      */
-    private void ensureAuthenticated(Long userId) {
-        if (userId == null) {
-            throw new BusinessException(ErrorCode.NOT_LOGGED_IN);
+    private Map<Long, List<Post>> buildChildrenMap(List<Long> rootIds) {
+        Map<Long, List<Post>> childrenMap = new java.util.HashMap<>();
+        List<Long> currentLevel = rootIds;
+
+        while (!currentLevel.isEmpty()) {
+            List<Post> children = postService.findChildren(currentLevel);
+            if (children.isEmpty()) {
+                break;
+            }
+            for (Post child : children) {
+                childrenMap.computeIfAbsent(child.getParentPostId(), key -> new ArrayList<>()).add(child);
+            }
+            currentLevel = children.stream().map(Post::getPostId).toList();
         }
+
+        return childrenMap;
+    }
+
+    /**
+     * 게시글과 하위 댓글을 PostThreadResponse 구조로 재귀 변환한다.
+     *
+     * @param post 현재 게시글
+     * @param childrenMap 부모-자식 매핑
+     * @return 스레드 응답
+     */
+    private PostThreadResponse toThreadResponse(Post post, Map<Long, List<Post>> childrenMap) {
+        List<PostThreadResponse> replies = childrenMap.getOrDefault(post.getPostId(), List.of()).stream()
+                .map(child -> toThreadResponse(child, childrenMap))
+                .toList();
+        return PostThreadResponse.from(post, replies);
     }
 }

--- a/src/test/java/com/workhub/post/service/PostServiceTest.java
+++ b/src/test/java/com/workhub/post/service/PostServiceTest.java
@@ -20,12 +20,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.anyLong;
 
 @ExtendWith(SpringExtension.class)
 public class PostServiceTest {
@@ -35,7 +37,6 @@ public class PostServiceTest {
     PostService postService;
     @Mock
     ProjectService projectService;
-
     CreatePostService createPostService;
     UpdatePostService updatePostService;
     DeletePostService deletePostService;
@@ -45,6 +46,7 @@ public class PostServiceTest {
         createPostService = new CreatePostService(postService, projectService);
         updatePostService = new UpdatePostService(postService, projectService);
         deletePostService = new DeletePostService(postService, projectService);
+        given(postRepository.findByParentPostIdAndDeletedAtIsNull(anyLong())).willReturn(Collections.emptyList());
     }
 
     @Test
@@ -191,7 +193,6 @@ public class PostServiceTest {
     @Test
     @DisplayName("삭제 대상 게시글이 없으면 예외를 던진다")
     void delete_withPostNotFound_shouldThrow() {
-        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(99L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 99L, 30L))
@@ -212,7 +213,6 @@ public class PostServiceTest {
                 .userId(30L)
                 .build();
         deleted.markDeleted();
-        given(projectService.validateProject(10L)).willReturn(mockProject(10L));
         given(postRepository.findByPostIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(deleted));
 
         assertThatThrownBy(() -> deletePostService.delete(10L, 20L, 1L, 30L))
@@ -276,4 +276,5 @@ public class PostServiceTest {
                 .status(Status.IN_PROGRESS)
                 .build();
     }
+
 }


### PR DESCRIPTION
• ## PR 요약

  - [x] 기능 추가
  - [ ] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  ———

  ## 주요 변경 사항

  - post/record/response/PostThreadResponse: 기존 요약 DTO를 스레드 구조로 교체하고, 미리보기 텍스트를 생성해 계층형 응답을 지원했습니다.
  - post/service/PostService, post/repository/PostSpecifications: 프로젝트 노드/검색 조건/해시태그/루트 글 필터를 조합한 부모 게시글 조회와 자식 글 일괄 조회 기능을 추가했습니다.
  - post/service/ReadPostService: 부모 페이지 결과를 바탕으로 children map을 구성하고 재귀적으로 PostThreadResponse를 만들어 게시글 목록 API가 전체 스레드를 반환하도록 변경했습니다.
  - post/service/CreatePostService, DeletePostService: 부모 글 존재·노드 일치·삭제 여부 검증을 강화하고, 삭제 시 모든 하위 글을 재귀적으로 soft-delete 하도록 했습니다.
  - post/service/PostServiceTest: 신규 서비스 메서드와 예외 시나리오를 검증하는 단위 테스트를 추가했습니다.

  ———

  ## 체크리스트

  ### 코드 품질

  - [x] 코드가 정상적으로 빌드됩니다.
  - [x] 로컬 테스트를 통과했습니다.
  - [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
  - [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

  ### 기능 검증

  - [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
  - [x] 예외 상황을 고려한 테스트를 진행했습니다.
  - [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

  ### 문서 및 이슈 연동

  - [X] 관련 이슈 번호를 연결했습니다. (예: Closes #123)
  - [ ] 변경된 부분을 README 또는 문서에 반영했습니다.

  ———

  ## 참고 사항

