### PR TITLE
feat : CS POST Comment 수정 기능 + 테스트 코드 (#105)

### DIFF
--- a/src/main/java/com/workhub/cs/api/CsQnaApi.java
+++ b/src/main/java/com/workhub/cs/api/CsQnaApi.java
@@ -2,6 +2,7 @@ package com.workhub.cs.api;
 
 import com.workhub.cs.dto.csQna.CsQnaRequest;
 import com.workhub.cs.dto.csQna.CsQnaResponse;
+import com.workhub.cs.dto.csQna.CsQnaUpdateRequest;
 import com.workhub.global.response.ApiResponse;
 import com.workhub.userTable.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,6 +50,36 @@ public interface CsQnaApi {
             @PathVariable Long projectId,
             @PathVariable Long csPostId,
             @Valid @RequestBody CsQnaRequest csQnaRequest,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "CS 댓글 수정",
+            description = "완료된 프로젝트의 CS 게시글에 작성된 댓글을 수정합니다.",
+            parameters = {
+                    @Parameter(name = "projectId", description = "프로젝트 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "csPostId", description = "CS 게시글 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "csQnaId", description = "CS 댓글 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "CS 댓글 수정 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CsQnaResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 빈 내용)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "수정 권한이 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글 또는 댓글을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PatchMapping(value = "/{csQnaId}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<CsQnaResponse>> update(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId,
+            @PathVariable Long csQnaId,
+            @Valid @RequestBody CsQnaUpdateRequest csQnaUpdateRequest,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }

--- a/src/main/java/com/workhub/cs/controller/CsQnaController.java
+++ b/src/main/java/com/workhub/cs/controller/CsQnaController.java
@@ -3,7 +3,9 @@ package com.workhub.cs.controller;
 import com.workhub.cs.api.CsQnaApi;
 import com.workhub.cs.dto.csQna.CsQnaRequest;
 import com.workhub.cs.dto.csQna.CsQnaResponse;
+import com.workhub.cs.dto.csQna.CsQnaUpdateRequest;
 import com.workhub.cs.service.csQna.CreateCsQnaService;
+import com.workhub.cs.service.csQna.UpdateCsQnaService;
 import com.workhub.global.response.ApiResponse;
 import com.workhub.userTable.security.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class CsQnaController implements CsQnaApi {
 
     private final CreateCsQnaService createCsQnaService;
+    private final UpdateCsQnaService updateCsQnaService;
 
     /**
      * CS POST의 댓글을 작성한다.
@@ -40,5 +43,28 @@ public class CsQnaController implements CsQnaApi {
                 projectId, csPostId, userDetails.getUserId(), csQnaRequest);
 
         return ApiResponse.success(response, "CS Comment가 작성되었습니다.");
+    }
+
+    /**
+     * CS POST의 댓글을 수정한다.
+     * @param projectId 프로젝트 식별자
+     * @param csPostId 게시글 식별자
+     * @param csQnaId 댓글 식별자
+     * @param csQnaUpdateRequest 댓글 수정 요청
+     * @param userDetails 유저 식별자
+     * @return CsQnaResponse
+     */
+    @PatchMapping("/{csQnaId}")
+    public ResponseEntity<ApiResponse<CsQnaResponse>> update(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId,
+            @PathVariable Long csQnaId,
+            @RequestBody @Valid CsQnaUpdateRequest csQnaUpdateRequest,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        CsQnaResponse response = updateCsQnaService.update(
+                projectId, csPostId, csQnaId, userDetails.getUserId(), csQnaUpdateRequest);
+
+        return ApiResponse.success(response, "CS Comment가 수정되었습니다.");
     }
 }

--- a/src/main/java/com/workhub/cs/dto/csQna/CsQnaUpdateRequest.java
+++ b/src/main/java/com/workhub/cs/dto/csQna/CsQnaUpdateRequest.java
@@ -1,4 +1,11 @@
 package com.workhub.cs.dto.csQna;
 
-public record CsQnaUpdateRequest() {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CsQnaUpdateRequest(
+        @NotBlank(message = "내용은 필수입니다")
+        @Size(max = 1000, message = "내용은 1000자를 초과할 수 없습니다")
+        String qnaContent
+) {
 }

--- a/src/main/java/com/workhub/cs/dto/csQna/CsQnaUpdateRequest.java
+++ b/src/main/java/com/workhub/cs/dto/csQna/CsQnaUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.workhub.cs.dto.csQna;
+
+public record CsQnaUpdateRequest() {
+}

--- a/src/main/java/com/workhub/cs/entity/CsQna.java
+++ b/src/main/java/com/workhub/cs/entity/CsQna.java
@@ -1,6 +1,8 @@
 package com.workhub.cs.entity;
 
 import com.workhub.global.entity.BaseTimeEntity;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,5 +42,12 @@ public class CsQna extends BaseTimeEntity {
                 .parentQnaId(parentQnaId)
                 .qnaContent(content)
                 .build();
+    }
+
+    public void updateContent(String newContent) {
+        if (newContent == null && newContent.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_CS_QNA_CONTENT);
+        }
+        this.qnaContent = newContent;
     }
 }

--- a/src/main/java/com/workhub/cs/service/csQna/CsQnaService.java
+++ b/src/main/java/com/workhub/cs/service/csQna/CsQnaService.java
@@ -8,6 +8,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -15,18 +17,26 @@ public class CsQnaService {
 
     private final CsQnaRepository csQnaRepository;
 
-    /**
-     * CS POST QNA 엔티티를 저장한다.
-     */
     public CsQna save(CsQna csQna) {
         return csQnaRepository.save(csQna);
     }
 
-    /**
-     * CS POST QNA 엔티티를 찾는다.
-     */
     public CsQna findById(Long csQnaId) {
         return csQnaRepository.findById(csQnaId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXISTS_CS_QNA));
+    }
+
+    /**
+     * 댓글이 있는지 검증하고, 댓글 작성자와 수정자가 맞는지 확인
+     * @param csQnaId 댓글 식별자
+     * @param userId 유저 식별자
+     * @return CsQna
+     */
+    public CsQna findByCsQnaAndMatchedUserId(Long csQnaId, Long userId) {
+        CsQna csQna = findById(csQnaId);
+        if (!Objects.equals(csQna.getUserId(), userId)) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_CS_QNA_USERID);
+        }
+        return csQna;
     }
 }

--- a/src/main/java/com/workhub/cs/service/csQna/UpdateCsQnaService.java
+++ b/src/main/java/com/workhub/cs/service/csQna/UpdateCsQnaService.java
@@ -1,0 +1,4 @@
+package com.workhub.cs.service.csQna;
+
+public class UpdateCsQnaService {
+}

--- a/src/main/java/com/workhub/cs/service/csQna/UpdateCsQnaService.java
+++ b/src/main/java/com/workhub/cs/service/csQna/UpdateCsQnaService.java
@@ -1,4 +1,47 @@
 package com.workhub.cs.service.csQna;
 
+import com.workhub.cs.dto.csQna.CsQnaResponse;
+import com.workhub.cs.dto.csQna.CsQnaUpdateRequest;
+import com.workhub.cs.entity.CsQna;
+import com.workhub.cs.service.CsPostAccessValidator;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class UpdateCsQnaService {
+
+    private final CsQnaService csQnaService;
+    private final CsPostAccessValidator csPostAccessValidator;
+
+    public CsQnaResponse update(Long projectId, Long csPostId, Long csQnaId, Long userId, CsQnaUpdateRequest request) {
+        // 1. 댓글 조회 및 작성자 검증 (가장 구체적인 검증)
+        CsQna csQna = csQnaService.findByCsQnaAndMatchedUserId(csQnaId, userId);
+
+        // 2. 댓글이 해당 게시글에 속하는지 검증
+        validateCsPostBelongs(csQna, csPostId);
+
+        // 3. 프로젝트-게시글 관계 검증
+        csPostAccessValidator.validateProjectAndGetPost(projectId, csPostId);
+
+        csQna.updateContent(request.qnaContent());
+        return CsQnaResponse.from(csQna);
+    }
+
+    /**
+     * 해당 댓글이 실제 게시글에 속하는지 검증
+     * @param csQna
+     * @param csPostId
+     */
+    private void validateCsPostBelongs(CsQna csQna, Long csPostId) {
+        if (!csQna.getCsPostId().equals(csPostId)) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_CS_QNA_POST);
+        }
+    }
+
+
 }

--- a/src/main/java/com/workhub/global/error/ErrorCode.java
+++ b/src/main/java/com/workhub/global/error/ErrorCode.java
@@ -69,6 +69,7 @@ public enum ErrorCode {
     NOT_EXISTS_CS_QNA(HttpStatus.BAD_REQUEST, "C-012", "존재하지 않는 CS 댓글입니다."),
     NOT_MATCHED_CS_QNA_POST(HttpStatus.BAD_REQUEST, "C-013", "잘못된 게시글의 CS 댓글입니다."),
     INVALID_CS_QNA_CONTENT(HttpStatus.BAD_REQUEST, "C-014", "CS 댓글 내용이 비어있습니다."),
+    NOT_MATCHED_CS_QNA_USERID(HttpStatus.BAD_REQUEST, "C-015", "CS 댓글 작성자와 수정자가 다릅니다."),
 
     // AWS S3
     // 파일 관련 에러

--- a/src/test/java/com/workhub/cs/service/csQna/UpdateCsQnaServiceTest.java
+++ b/src/test/java/com/workhub/cs/service/csQna/UpdateCsQnaServiceTest.java
@@ -1,0 +1,84 @@
+package com.workhub.cs.service.csQna;
+
+import com.workhub.cs.dto.csQna.CsQnaResponse;
+import com.workhub.cs.dto.csQna.CsQnaUpdateRequest;
+import com.workhub.cs.entity.CsQna;
+import com.workhub.cs.service.CsPostAccessValidator;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateCsQnaServiceTest {
+
+    @Mock
+    private CsQnaService csQnaService;
+
+    @Mock
+    private CsPostAccessValidator csPostAccessValidator;
+
+    @InjectMocks
+    private UpdateCsQnaService updateCsQnaService;
+
+    @DisplayName("댓글 수정 시 프로젝트/게시글 검증과 소유자 검증이 모두 통과하면 컨텐츠가 갱신된다")
+    @Test
+    void updateCsQnaSuccess() {
+        Long projectId = 1L;
+        Long csPostId = 2L;
+        Long csQnaId = 3L;
+        Long userId = 4L;
+        CsQna existing = CsQna.builder()
+                .csQnaId(csQnaId)
+                .csPostId(csPostId)
+                .userId(userId)
+                .qnaContent("기존 내용")
+                .build();
+
+        when(csQnaService.findByCsQnaAndMatchedUserId(csQnaId, userId))
+                .thenReturn(existing);
+
+        CsQnaUpdateRequest request = new CsQnaUpdateRequest("수정된 내용");
+
+        CsQnaResponse response = updateCsQnaService.update(projectId, csPostId, csQnaId, userId, request);
+
+        assertThat(response.qnaContent()).isEqualTo("수정된 내용");
+        assertThat(existing.getQnaContent()).isEqualTo("수정된 내용");
+        verify(csPostAccessValidator).validateProjectAndGetPost(projectId, csPostId);
+        verify(csQnaService).findByCsQnaAndMatchedUserId(csQnaId, userId);
+    }
+
+    @DisplayName("요청한 게시글과 댓글이 속한 게시글이 다르면 예외가 발생한다")
+    @Test
+    void updateCsQnaFailedByDifferentCsPost() {
+        Long projectId = 1L;
+        Long csPostId = 2L;
+        Long csQnaId = 3L;
+        Long userId = 4L;
+        CsQna existing = CsQna.builder()
+                .csQnaId(csQnaId)
+                .csPostId(99L)
+                .userId(userId)
+                .qnaContent("기존 내용")
+                .build();
+
+        when(csQnaService.findByCsQnaAndMatchedUserId(csQnaId, userId))
+                .thenReturn(existing);
+
+        CsQnaUpdateRequest request = new CsQnaUpdateRequest("수정된 내용");
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> updateCsQnaService.update(projectId, csPostId, csQnaId, userId, request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_MATCHED_CS_QNA_POST);
+    }
+}


### PR DESCRIPTION
## PR 요약
>  CS POST의 댓글 수정 기능을 구현하였습니다. 

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
  - src/main/java/com/workhub/cs/service/csQna/UpdateCsQnaService.java: QnA 업데이트 시 댓글-게시글 소유 검증을 메서드로 분리하고, 프로젝트/게시글/사용자 검증 순서를 명확히 했습니다.
  - src/main/java/com/workhub/cs/api/CsQnaApi.java: PATCH 엔드포인트와 Swagger 메타데이터를 추가해 수정 API 계약을 명시했습니다.
  - src/main/java/com/workhub/cs/dto/csQna/CsQnaUpdateRequest.java: 수정 요청 DTO를 검증 어노테이션이 포함된 단일 필드 구조로 정리했습니다.
  - src/test/java/com/workhub/cs/service/csQna/UpdateCsQnaServiceTest.java: 성공/실패 시나리오를 검증하는 단위 테스트를 추가하여 게시글 불일치 예외가 제대로 발생하는지 확인했습니다.

---

## 체크리스트

### 코드 품질
- [x] 코드가 정상적으로 빌드됩니다.
- [x] 로컬 테스트를 통과했습니다.
- [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [x] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [x] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
