### PR TITLE
feat : CS POST Comment 댓글 리스트 불러오기 (#105)

### DIFF
--- a/src/main/java/com/workhub/cs/api/CsQnaApi.java
+++ b/src/main/java/com/workhub/cs/api/CsQnaApi.java
@@ -15,15 +15,20 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "CS 댓글 관리", description = "CS 게시글의 QnA API")
-@RequestMapping("/api/v1/projects/{projectId}/csPosts/{csPostId}")
+@RequestMapping("/api/v1/projects/{projectId}/csPosts/{csPostId}/qnas")
 public interface CsQnaApi {
 
     @Operation(
@@ -81,5 +86,29 @@ public interface CsQnaApi {
             @PathVariable Long csQnaId,
             @Valid @RequestBody CsQnaUpdateRequest csQnaUpdateRequest,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "CS 댓글 목록 조회",
+            description = "완료된 프로젝트의 CS 게시글에 작성된 댓글 목록을 계층 구조로 조회합니다. 최상위 댓글만 페이징되며, 각 댓글의 답글은 children 필드에 모두 포함됩니다.",
+            parameters = {
+                    @Parameter(name = "projectId", description = "프로젝트 식별자", in = ParameterIn.PATH, required = true),
+                    @Parameter(name = "csPostId", description = "CS 게시글 식별자", in = ParameterIn.PATH, required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "CS 댓글 목록 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<ApiResponse<Page<CsQnaResponse>>> findCsQnas(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId,
+            @PageableDefault(size = 20) Pageable pageable
     );
 }

--- a/src/main/java/com/workhub/cs/controller/CsQnaController.java
+++ b/src/main/java/com/workhub/cs/controller/CsQnaController.java
@@ -5,21 +5,26 @@ import com.workhub.cs.dto.csQna.CsQnaRequest;
 import com.workhub.cs.dto.csQna.CsQnaResponse;
 import com.workhub.cs.dto.csQna.CsQnaUpdateRequest;
 import com.workhub.cs.service.csQna.CreateCsQnaService;
+import com.workhub.cs.service.csQna.ReadCsQnaService;
 import com.workhub.cs.service.csQna.UpdateCsQnaService;
 import com.workhub.global.response.ApiResponse;
 import com.workhub.userTable.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/projects/{projectId}/csPosts/{csPostId}")
+@RequestMapping("/api/v1/projects/{projectId}/csPosts/{csPostId}/qnas")
 public class CsQnaController implements CsQnaApi {
 
     private final CreateCsQnaService createCsQnaService;
+    private final ReadCsQnaService readCsQnaService;
     private final UpdateCsQnaService updateCsQnaService;
 
     /**
@@ -46,7 +51,29 @@ public class CsQnaController implements CsQnaApi {
     }
 
     /**
+     * CS POST의 댓글 목록을 조회한다.
+     *
+     * @param projectId 프로젝트 식별자
+     * @param csPostId 게시글 식별자
+     * @param pageable 페이징 정보 (최상위 댓글 기준)
+     * @return Page<CsQnaResponse> 계층 구조로 구성된 댓글 목록
+     */
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<CsQnaResponse>>> findCsQnas(
+            @PathVariable Long projectId,
+            @PathVariable Long csPostId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Page<CsQnaResponse> response = readCsQnaService.findCsQnas(
+                projectId, csPostId, pageable);
+
+        return ApiResponse.success(response, "CS Comment 목록이 조회되었습니다.");
+    }
+
+    /**
      * CS POST의 댓글을 수정한다.
+     *
      * @param projectId 프로젝트 식별자
      * @param csPostId 게시글 식별자
      * @param csQnaId 댓글 식별자
@@ -54,6 +81,7 @@ public class CsQnaController implements CsQnaApi {
      * @param userDetails 유저 식별자
      * @return CsQnaResponse
      */
+    @Override
     @PatchMapping("/{csQnaId}")
     public ResponseEntity<ApiResponse<CsQnaResponse>> update(
             @PathVariable Long projectId,

--- a/src/main/java/com/workhub/cs/dto/csQna/CsQnaResponse.java
+++ b/src/main/java/com/workhub/cs/dto/csQna/CsQnaResponse.java
@@ -3,6 +3,8 @@ package com.workhub.cs.dto.csQna;
 import com.workhub.cs.entity.CsQna;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public record CsQnaResponse(
         Long csQnaId,
@@ -11,7 +13,8 @@ public record CsQnaResponse(
         Long parentQnaId,
         String qnaContent,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        List<CsQnaResponse> children
 ) {
     public static CsQnaResponse from(CsQna csQna) {
         return new CsQnaResponse(
@@ -21,7 +24,21 @@ public record CsQnaResponse(
                 csQna.getParentQnaId(),
                 csQna.getQnaContent(),
                 csQna.getCreatedAt(),
-                csQna.getUpdatedAt()
+                csQna.getUpdatedAt(),
+                new ArrayList<>()
+        );
+    }
+
+    public CsQnaResponse withChildren(List<CsQnaResponse> children) {
+        return new CsQnaResponse(
+                csQnaId,
+                csPostId,
+                userId,
+                parentQnaId,
+                qnaContent,
+                createdAt,
+                updatedAt,
+                children
         );
     }
 }

--- a/src/main/java/com/workhub/cs/repository/csQna/CsQnaRepository.java
+++ b/src/main/java/com/workhub/cs/repository/csQna/CsQnaRepository.java
@@ -3,5 +3,5 @@ package com.workhub.cs.repository.csQna;
 import com.workhub.cs.entity.CsQna;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CsQnaRepository extends JpaRepository<CsQna,Long> {
+public interface CsQnaRepository extends JpaRepository<CsQna, Long>, CsQnaRepositoryCustom {
 }

--- a/src/main/java/com/workhub/cs/repository/csQna/CsQnaRepositoryCustom.java
+++ b/src/main/java/com/workhub/cs/repository/csQna/CsQnaRepositoryCustom.java
@@ -1,0 +1,25 @@
+package com.workhub.cs.repository.csQna;
+
+import com.workhub.cs.entity.CsQna;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CsQnaRepositoryCustom {
+
+    /**
+     * CS 게시글의 모든 댓글을 조회한다 (부모 댓글 + 답글 모두 포함).
+     * @param csPostId 게시글 식별자
+     * @param pageable 페이징 정보 (최상위 댓글 기준)
+     * @return Page<CsQna> 최상위 댓글만 페이징, 각 댓글의 답글은 전체 포함
+     */
+    Page<CsQna> findCsQnasWithReplies(Long csPostId, Pageable pageable);
+
+    /**
+     * CS 게시글의 모든 댓글을 조회한다 (페이징 없이).
+     * @param csPostId 게시글 식별자
+     * @return List<CsQna>
+     */
+    List<CsQna> findAllByCsPostId(Long csPostId);
+}

--- a/src/main/java/com/workhub/cs/repository/csQna/CsQnaRepositoryImpl.java
+++ b/src/main/java/com/workhub/cs/repository/csQna/CsQnaRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.workhub.cs.repository.csQna;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.workhub.cs.entity.CsQna;
+import com.workhub.cs.entity.QCsQna;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CsQnaRepositoryImpl implements CsQnaRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CsQna> findCsQnasWithReplies(Long csPostId, Pageable pageable) {
+        QCsQna csQna = QCsQna.csQna;
+
+        // 최상위 댓글만 페이징하여 조회
+        List<CsQna> topLevelComments = queryFactory
+                .selectFrom(csQna)
+                .where(
+                        csPostIdEq(csPostId),
+                        csQna.parentQnaId.isNull()
+                )
+                .orderBy(csQna.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 최상위 댓글의 총 개수
+        Long total = queryFactory
+                .select(csQna.count())
+                .from(csQna)
+                .where(
+                        csPostIdEq(csPostId),
+                        csQna.parentQnaId.isNull()
+                )
+                .fetchOne();
+
+        return new PageImpl<>(topLevelComments, pageable, total == null ? 0 : total);
+    }
+
+    @Override
+    public List<CsQna> findAllByCsPostId(Long csPostId) {
+        QCsQna csQna = QCsQna.csQna;
+
+        return queryFactory
+                .selectFrom(csQna)
+                .where(csPostIdEq(csPostId))
+                .orderBy(csQna.createdAt.asc())
+                .fetch();
+    }
+
+    private BooleanExpression csPostIdEq(Long csPostId) {
+        return csPostId == null ? null : QCsQna.csQna.csPostId.eq(csPostId);
+    }
+}

--- a/src/main/java/com/workhub/cs/service/csQna/CsQnaService.java
+++ b/src/main/java/com/workhub/cs/service/csQna/CsQnaService.java
@@ -6,8 +6,11 @@ import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -17,17 +20,23 @@ public class CsQnaService {
 
     private final CsQnaRepository csQnaRepository;
 
+    /**
+     * CS QNA 엔티티를 저장한다.
+     */
     public CsQna save(CsQna csQna) {
         return csQnaRepository.save(csQna);
     }
 
+    /**
+     * 식별자로 CS QNA를 조회한다.
+     */
     public CsQna findById(Long csQnaId) {
         return csQnaRepository.findById(csQnaId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXISTS_CS_QNA));
     }
 
     /**
-     * 댓글이 있는지 검증하고, 댓글 작성자와 수정자가 맞는지 확인
+     * 댓글이 있는지 검증하고, 댓글 작성자와 수정자가 맞는지 확인한다.
      * @param csQnaId 댓글 식별자
      * @param userId 유저 식별자
      * @return CsQna
@@ -38,5 +47,24 @@ public class CsQnaService {
             throw new BusinessException(ErrorCode.NOT_MATCHED_CS_QNA_USERID);
         }
         return csQna;
+    }
+
+    /**
+     * CS 게시글의 모든 댓글을 조회한다 (페이징 없이).
+     * @param csPostId 게시글 식별자
+     * @return List<CsQna>
+     */
+    public List<CsQna> findAllByCsPostId(Long csPostId) {
+        return csQnaRepository.findAllByCsPostId(csPostId);
+    }
+
+    /**
+     * CS 게시글의 최상위 댓글을 페이징하여 조회한다.
+     * @param csPostId 게시글 식별자
+     * @param pageable 페이징 정보
+     * @return Page<CsQna>
+     */
+    public Page<CsQna> findCsQnasWithReplies(Long csPostId, Pageable pageable) {
+        return csQnaRepository.findCsQnasWithReplies(csPostId, pageable);
     }
 }

--- a/src/main/java/com/workhub/cs/service/csQna/ReadCsQnaService.java
+++ b/src/main/java/com/workhub/cs/service/csQna/ReadCsQnaService.java
@@ -1,0 +1,88 @@
+package com.workhub.cs.service.csQna;
+
+import com.workhub.cs.dto.csQna.CsQnaResponse;
+import com.workhub.cs.entity.CsQna;
+import com.workhub.cs.service.CsPostAccessValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadCsQnaService {
+
+    private final CsQnaService csQnaService;
+    private final CsPostAccessValidator csPostAccessValidator;
+
+    /**
+     * CS 게시글의 댓글 목록을 계층 구조로 조회한다.
+     * 최상위 댓글만 페이징하며, 각 댓글의 답글은 모두 포함된다.
+     * @param projectId 프로젝트 식별자
+     * @param csPostId 게시글 식별자
+     * @param pageable 페이징 정보 (최상위 댓글 기준)
+     * @return Page<CsQnaResponse> 계층 구조로 구성된 댓글 목록
+     */
+    public Page<CsQnaResponse> findCsQnas(Long projectId, Long csPostId, Pageable pageable) {
+        csPostAccessValidator.validateProjectAndGetPost(projectId, csPostId);
+
+        // 1. 모든 댓글 조회 (부모 댓글 + 답글)
+        List<CsQna> allComments = csQnaService.findAllByCsPostId(csPostId);
+
+        // 2. 최상위 댓글만 페이징
+        Page<CsQna> topLevelComments = csQnaService.findCsQnasWithReplies(csPostId, pageable);
+
+        // 3. 계층 구조로 변환
+        List<CsQnaResponse> hierarchicalComments = buildHierarchy(
+                topLevelComments.getContent(),
+                allComments
+        );
+
+        return new PageImpl<>(
+                hierarchicalComments,
+                pageable,
+                topLevelComments.getTotalElements()
+        );
+    }
+
+    /**
+     * 댓글 목록을 계층 구조로 변환한다.
+     * @param topLevelComments 최상위 댓글 목록
+     * @param allComments 모든 댓글 목록 (부모 + 자식)
+     * @return 계층 구조로 구성된 댓글 목록
+     */
+    private List<CsQnaResponse> buildHierarchy(List<CsQna> topLevelComments, List<CsQna> allComments) {
+        // parentQnaId를 키로 하는 맵 생성 (자식 댓글 그룹화)
+        Map<Long, List<CsQna>> childrenMap = allComments.stream()
+                .filter(comment -> comment.getParentQnaId() != null)
+                .collect(Collectors.groupingBy(CsQna::getParentQnaId));
+
+        return topLevelComments.stream()
+                .map(parent -> buildCommentWithChildren(parent, childrenMap))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 재귀적으로 댓글과 그 자식 댓글들을 구성한다.
+     * @param comment 현재 댓글
+     * @param childrenMap 부모 ID를 키로 하는 자식 댓글 맵
+     * @return 자식 댓글을 포함한 CsQnaResponse
+     */
+    private CsQnaResponse buildCommentWithChildren(CsQna comment, Map<Long, List<CsQna>> childrenMap) {
+        List<CsQna> children = childrenMap.getOrDefault(comment.getCsQnaId(), new ArrayList<>());
+
+        List<CsQnaResponse> childResponses = children.stream()
+                .map(child -> buildCommentWithChildren(child, childrenMap))
+                .collect(Collectors.toList());
+
+        return CsQnaResponse.from(comment).withChildren(childResponses);
+    }
+}

--- a/src/test/java/com/workhub/cs/service/csQna/ReadCsQnaServiceTest.java
+++ b/src/test/java/com/workhub/cs/service/csQna/ReadCsQnaServiceTest.java
@@ -1,0 +1,233 @@
+package com.workhub.cs.service.csQna;
+
+import com.workhub.cs.dto.csQna.CsQnaResponse;
+import com.workhub.cs.entity.CsPost;
+import com.workhub.cs.entity.CsQna;
+import com.workhub.cs.service.CsPostAccessValidator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReadCsQnaServiceTest {
+
+    @Mock
+    private CsQnaService csQnaService;
+
+    @Mock
+    private CsPostAccessValidator csPostAccessValidator;
+
+    @InjectMocks
+    private ReadCsQnaService readCsQnaService;
+
+    @Test
+    @DisplayName("댓글 목록을 계층 구조로 조회한다.")
+    void givenCsPostId_whenFindCsQnas_thenReturnsHierarchicalComments() {
+        Long projectId = 1L;
+        Long csPostId = 2L;
+        Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
+
+        // 최상위 댓글
+        List<CsQna> topLevelComments = List.of(
+                CsQna.builder()
+                        .csQnaId(10L)
+                        .csPostId(csPostId)
+                        .userId(3L)
+                        .parentQnaId(null)
+                        .qnaContent("첫 번째 댓글")
+                        .build(),
+                CsQna.builder()
+                        .csQnaId(11L)
+                        .csPostId(csPostId)
+                        .userId(4L)
+                        .parentQnaId(null)
+                        .qnaContent("두 번째 댓글")
+                        .build()
+        );
+
+        // 모든 댓글 (최상위 + 답글)
+        List<CsQna> allComments = List.of(
+                CsQna.builder().csQnaId(10L).csPostId(csPostId).userId(3L).parentQnaId(null).qnaContent("첫 번째 댓글").build(),
+                CsQna.builder().csQnaId(20L).csPostId(csPostId).userId(5L).parentQnaId(10L).qnaContent("첫 번째 댓글의 답글 1").build(),
+                CsQna.builder().csQnaId(21L).csPostId(csPostId).userId(6L).parentQnaId(10L).qnaContent("첫 번째 댓글의 답글 2").build(),
+                CsQna.builder().csQnaId(11L).csPostId(csPostId).userId(4L).parentQnaId(null).qnaContent("두 번째 댓글").build()
+        );
+
+        Page<CsQna> mockPage = new PageImpl<>(topLevelComments, pageable, 2);
+
+        when(csPostAccessValidator.validateProjectAndGetPost(projectId, csPostId))
+                .thenReturn(CsPost.builder().csPostId(csPostId).projectId(projectId).userId(1L).title("t").content("c").build());
+        when(csQnaService.findAllByCsPostId(csPostId)).thenReturn(allComments);
+        when(csQnaService.findCsQnasWithReplies(csPostId, pageable)).thenReturn(mockPage);
+
+        Page<CsQnaResponse> result = readCsQnaService.findCsQnas(projectId, csPostId, pageable);
+
+        verify(csPostAccessValidator).validateProjectAndGetPost(projectId, csPostId);
+        verify(csQnaService).findAllByCsPostId(csPostId);
+        verify(csQnaService).findCsQnasWithReplies(csPostId, pageable);
+
+        // 페이징 검증
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+
+        // 첫 번째 댓글 검증
+        CsQnaResponse firstComment = result.getContent().get(0);
+        assertThat(firstComment.csQnaId()).isEqualTo(10L);
+        assertThat(firstComment.qnaContent()).isEqualTo("첫 번째 댓글");
+        assertThat(firstComment.parentQnaId()).isNull();
+        assertThat(firstComment.children()).hasSize(2);
+
+        // 첫 번째 댓글의 답글 검증
+        assertThat(firstComment.children().get(0).csQnaId()).isEqualTo(20L);
+        assertThat(firstComment.children().get(0).qnaContent()).isEqualTo("첫 번째 댓글의 답글 1");
+        assertThat(firstComment.children().get(0).parentQnaId()).isEqualTo(10L);
+
+        assertThat(firstComment.children().get(1).csQnaId()).isEqualTo(21L);
+        assertThat(firstComment.children().get(1).qnaContent()).isEqualTo("첫 번째 댓글의 답글 2");
+        assertThat(firstComment.children().get(1).parentQnaId()).isEqualTo(10L);
+
+        // 두 번째 댓글 검증
+        CsQnaResponse secondComment = result.getContent().get(1);
+        assertThat(secondComment.csQnaId()).isEqualTo(11L);
+        assertThat(secondComment.qnaContent()).isEqualTo("두 번째 댓글");
+        assertThat(secondComment.parentQnaId()).isNull();
+        assertThat(secondComment.children()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("답글이 없는 댓글만 있을 때 정상 조회한다.")
+    void givenTopLevelCommentsOnly_whenFindCsQnas_thenReturnsCommentsWithEmptyChildren() {
+        Long projectId = 1L;
+        Long csPostId = 2L;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        List<CsQna> topLevelComments = List.of(
+                CsQna.builder().csQnaId(10L).csPostId(csPostId).userId(3L).parentQnaId(null).qnaContent("댓글 1").build(),
+                CsQna.builder().csQnaId(11L).csPostId(csPostId).userId(4L).parentQnaId(null).qnaContent("댓글 2").build()
+        );
+
+        Page<CsQna> mockPage = new PageImpl<>(topLevelComments, pageable, 2);
+
+        when(csPostAccessValidator.validateProjectAndGetPost(projectId, csPostId))
+                .thenReturn(CsPost.builder().csPostId(csPostId).projectId(projectId).userId(1L).title("t").content("c").build());
+        when(csQnaService.findAllByCsPostId(csPostId)).thenReturn(topLevelComments);
+        when(csQnaService.findCsQnasWithReplies(csPostId, pageable)).thenReturn(mockPage);
+
+        Page<CsQnaResponse> result = readCsQnaService.findCsQnas(projectId, csPostId, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).children()).isEmpty();
+        assertThat(result.getContent().get(1).children()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("빈 페이지를 반환한다.")
+    void givenNoComments_whenFindCsQnas_thenReturnsEmptyPage() {
+        Long projectId = 1L;
+        Long csPostId = 2L;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Page<CsQna> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        when(csPostAccessValidator.validateProjectAndGetPost(projectId, csPostId))
+                .thenReturn(CsPost.builder().csPostId(csPostId).projectId(projectId).userId(1L).title("t").content("c").build());
+        when(csQnaService.findAllByCsPostId(csPostId)).thenReturn(List.of());
+        when(csQnaService.findCsQnasWithReplies(csPostId, pageable)).thenReturn(emptyPage);
+
+        Page<CsQnaResponse> result = readCsQnaService.findCsQnas(projectId, csPostId, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+        assertThat(result.getTotalPages()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("페이징 처리를 정확하게 수행한다.")
+    void givenPageableWithCustomSize_whenFindCsQnas_thenReturnsPaginatedResult() {
+        Long projectId = 1L;
+        Long csPostId = 2L;
+        Pageable pageable = PageRequest.of(1, 5);
+
+        List<CsQna> topLevelComments = List.of(
+                CsQna.builder().csQnaId(6L).csPostId(csPostId).userId(1L).parentQnaId(null).qnaContent("6번째 댓글").build(),
+                CsQna.builder().csQnaId(7L).csPostId(csPostId).userId(1L).parentQnaId(null).qnaContent("7번째 댓글").build(),
+                CsQna.builder().csQnaId(8L).csPostId(csPostId).userId(1L).parentQnaId(null).qnaContent("8번째 댓글").build(),
+                CsQna.builder().csQnaId(9L).csPostId(csPostId).userId(1L).parentQnaId(null).qnaContent("9번째 댓글").build(),
+                CsQna.builder().csQnaId(10L).csPostId(csPostId).userId(1L).parentQnaId(null).qnaContent("10번째 댓글").build()
+        );
+
+        Page<CsQna> mockPage = new PageImpl<>(topLevelComments, pageable, 15);
+
+        when(csPostAccessValidator.validateProjectAndGetPost(projectId, csPostId))
+                .thenReturn(CsPost.builder().csPostId(csPostId).projectId(projectId).userId(1L).title("t").content("c").build());
+        when(csQnaService.findAllByCsPostId(csPostId)).thenReturn(topLevelComments);
+        when(csQnaService.findCsQnasWithReplies(csPostId, pageable)).thenReturn(mockPage);
+
+        Page<CsQnaResponse> result = readCsQnaService.findCsQnas(projectId, csPostId, pageable);
+
+        assertThat(result.getContent()).hasSize(5);
+        assertThat(result.getTotalElements()).isEqualTo(15);
+        assertThat(result.getTotalPages()).isEqualTo(3);
+        assertThat(result.getNumber()).isEqualTo(1);
+        assertThat(result.getSize()).isEqualTo(5);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.hasPrevious()).isTrue();
+    }
+
+    @Test
+    @DisplayName("중첩된 답글 구조를 정확하게 구성한다.")
+    void givenNestedReplies_whenFindCsQnas_thenBuildsNestedStructure() {
+        Long projectId = 1L;
+        Long csPostId = 2L;
+        Pageable pageable = PageRequest.of(0, 20);
+
+        List<CsQna> topLevelComments = List.of(
+                CsQna.builder().csQnaId(1L).csPostId(csPostId).userId(1L).parentQnaId(null).qnaContent("최상위 댓글").build()
+        );
+
+        // 중첩 구조: 최상위 댓글 → 답글 → 답글의 답글
+        List<CsQna> allComments = List.of(
+                CsQna.builder().csQnaId(1L).csPostId(csPostId).userId(1L).parentQnaId(null).qnaContent("최상위 댓글").build(),
+                CsQna.builder().csQnaId(2L).csPostId(csPostId).userId(2L).parentQnaId(1L).qnaContent("1차 답글").build(),
+                CsQna.builder().csQnaId(3L).csPostId(csPostId).userId(3L).parentQnaId(2L).qnaContent("2차 답글").build()
+        );
+
+        Page<CsQna> mockPage = new PageImpl<>(topLevelComments, pageable, 1);
+
+        when(csPostAccessValidator.validateProjectAndGetPost(projectId, csPostId))
+                .thenReturn(CsPost.builder().csPostId(csPostId).projectId(projectId).userId(1L).title("t").content("c").build());
+        when(csQnaService.findAllByCsPostId(csPostId)).thenReturn(allComments);
+        when(csQnaService.findCsQnasWithReplies(csPostId, pageable)).thenReturn(mockPage);
+
+        Page<CsQnaResponse> result = readCsQnaService.findCsQnas(projectId, csPostId, pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+
+        CsQnaResponse topLevel = result.getContent().get(0);
+        assertThat(topLevel.csQnaId()).isEqualTo(1L);
+        assertThat(topLevel.children()).hasSize(1);
+
+        CsQnaResponse firstReply = topLevel.children().get(0);
+        assertThat(firstReply.csQnaId()).isEqualTo(2L);
+        assertThat(firstReply.children()).hasSize(1);
+
+        CsQnaResponse secondReply = firstReply.children().get(0);
+        assertThat(secondReply.csQnaId()).isEqualTo(3L);
+        assertThat(secondReply.children()).isEmpty();
+    }
+}


### PR DESCRIPTION
## PR 요약
> CS POST Comment 댓글 리스트 불러오는 기능을 구현하였습니다.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
- 스웨거 문서 등록
src/main/java/com/workhub/cs/api/CsQnaApi.java
src/main/java/com/workhub/cs/controller/CsQnaController.java

- querydsl 사용하여 페이징 처리하여 부모 + 자식 댓글 리스트로 반환
src/main/java/com/workhub/cs/repository/csQna/CsQnaRepository.java
src/main/java/com/workhub/cs/service/csQna/CsQnaService.java
src/main/java/com/workhub/cs/repository/csQna/CsQnaRepositoryCustom.java
src/main/java/com/workhub/cs/repository/csQna/CsQnaRepositoryImpl.java
src/main/java/com/workhub/cs/service/csQna/ReadCsQnaService.java

- 테스트 코드 작성
src/test/java/com/workhub/cs/service/csQna/ReadCsQnaServiceTest.java


---

## 체크리스트

### 코드 품질
- [x] 코드가 정상적으로 빌드됩니다.
- [x] 로컬 테스트를 통과했습니다.
- [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [x] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [x] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
