### PR TITLE
fix : 프로젝트 노드 상태 변경 시 projectId 추가(#13)

### DIFF
--- a/src/main/java/com/workhub/projectNode/api/ProjectNodeApi.java
+++ b/src/main/java/com/workhub/projectNode/api/ProjectNodeApi.java
@@ -104,6 +104,9 @@ public interface ProjectNodeApi {
     })
     @PatchMapping("{nodeId}/status")
     ResponseEntity<ApiResponse<String>> updateNodeStatus(
+            @Parameter(description = "프로젝트 ID", required = true)
+            @PathVariable("projectId") Long projectId,
+
             @Parameter(description = "노드 ID", required = true)
             @PathVariable("nodeId") Long nodeId,
 

--- a/src/main/java/com/workhub/projectNode/controller/ProjectNodeController.java
+++ b/src/main/java/com/workhub/projectNode/controller/ProjectNodeController.java
@@ -44,10 +44,11 @@ public class ProjectNodeController implements ProjectNodeApi {
 
     @Override
     @PatchMapping("{nodeId}/status")
-    public ResponseEntity<ApiResponse<String>> updateNodeStatus(@PathVariable("nodeId") Long nodeId,
+    public ResponseEntity<ApiResponse<String>> updateNodeStatus(@PathVariable("projectId") Long projectId,
+                                                                @PathVariable("nodeId") Long nodeId,
                                                                 @RequestBody UpdateNodeStatusRequest request) {
 
-        updateProjectNodeService.updateNodeStatus(nodeId, request);
+        updateProjectNodeService.updateNodeStatus(projectId, nodeId, request);
         return ApiResponse.success("노드 상태 변경 성공");
     }
 

--- a/src/main/java/com/workhub/projectNode/repository/ProjectNodeRepository.java
+++ b/src/main/java/com/workhub/projectNode/repository/ProjectNodeRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ProjectNodeRepository extends JpaRepository<ProjectNode,Long> {
 
     List<ProjectNode> findByProjectIdAndDeletedAtIsNullOrderByNodeOrderAsc(Long projectId);
+
+    Optional<ProjectNode> findByProjectNodeIdAndProjectId(Long projectNodeId, Long projectId);
 }

--- a/src/main/java/com/workhub/projectNode/service/ProjectNodeService.java
+++ b/src/main/java/com/workhub/projectNode/service/ProjectNodeService.java
@@ -30,4 +30,9 @@ public class ProjectNodeService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NODE_NOT_FOUND));
     }
 
+    public ProjectNode findByIdAndProjectId(Long projectNodeId, Long projectId) {
+        return projectNodeRepository.findByProjectNodeIdAndProjectId(projectNodeId, projectId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NODE_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/com/workhub/projectNode/service/UpdateProjectNodeService.java
+++ b/src/main/java/com/workhub/projectNode/service/UpdateProjectNodeService.java
@@ -31,12 +31,13 @@ public class UpdateProjectNodeService {
 
     /**
      * 프로젝트 노드 상태를 업데이트하고 변경 이력을 저장.
+     * @param projectId 프로젝트 ID
      * @param nodeId 업데이트할 프로젝트 노드 ID
      * @param request 변경할 상태 정보
      */
-    public void updateNodeStatus(Long nodeId, UpdateNodeStatusRequest request) {
+    public void updateNodeStatus(Long projectId, Long nodeId, UpdateNodeStatusRequest request) {
 
-        ProjectNode original = projectNodeService.findById(nodeId);
+        ProjectNode original = projectNodeService.findByIdAndProjectId(nodeId, projectId);
         NodeSnapshot snapshot = NodeSnapshot.from(original);
 
         StatusValidator.validateStatusChange(original.getNodeStatus(), request.nodeStatus());

--- a/src/test/java/com/workhub/projectNode/service/ProjectNodeServiceTest.java
+++ b/src/test/java/com/workhub/projectNode/service/ProjectNodeServiceTest.java
@@ -195,4 +195,35 @@ class ProjectNodeServiceTest {
         assertThat(result).allMatch(node -> node.getProjectId().equals(targetProjectId));
         verify(projectNodeRepository).findByProjectIdAndDeletedAtIsNullOrderByNodeOrderAsc(targetProjectId);
     }
+
+    @Test
+    @DisplayName("노드 ID와 프로젝트 ID로 조회하면 해당 노드를 반환한다.")
+    void givenValidNodeIdAndProjectId_whenFindByIdAndProjectId_thenReturnProjectNode() {
+        Long nodeId = 1L;
+        Long projectId = 100L;
+        when(projectNodeRepository.findByProjectNodeIdAndProjectId(nodeId, projectId))
+                .thenReturn(Optional.of(mockProjectNode));
+
+        ProjectNode result = projectNodeService.findByIdAndProjectId(nodeId, projectId);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getProjectNodeId()).isEqualTo(nodeId);
+        assertThat(result.getProjectId()).isEqualTo(projectId);
+        verify(projectNodeRepository).findByProjectNodeIdAndProjectId(nodeId, projectId);
+    }
+
+    @Test
+    @DisplayName("노드 ID와 프로젝트 ID가 일치하지 않으면 예외를 발생시킨다.")
+    void givenMismatchedNodeIdAndProjectId_whenFindByIdAndProjectId_thenThrowException() {
+        Long nodeId = 1L;
+        Long wrongProjectId = 999L;
+        when(projectNodeRepository.findByProjectNodeIdAndProjectId(nodeId, wrongProjectId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> projectNodeService.findByIdAndProjectId(nodeId, wrongProjectId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_NODE_NOT_FOUND);
+
+        verify(projectNodeRepository).findByProjectNodeIdAndProjectId(nodeId, wrongProjectId);
+    }
 }


### PR DESCRIPTION
## PR 요약 #13 
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

- src/main/java/com/workhub/projectNode/service/UpdateProjectNodeService.java : 기존 생성된 노드 검색 시 projectId를 포함하여 검색 후 상태를 변경할 수 있도록 수정했습니다.

---

## 체크리스트

### 코드 품질
- [x] 코드가 정상적으로 빌드됩니다.
- [x] 로컬 테스트를 통과했습니다.
- [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [x] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [x] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
