### PR TITLE
 fix : 프로젝트 수정 시 히스토리 저장 스냅샷 방식으로 변경

### DIFF
--- a/src/main/java/com/workhub/project/api/ProjectApi.java
+++ b/src/main/java/com/workhub/project/api/ProjectApi.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Project", description = "프로젝트 관리 API")
+@Tag(name = "프로젝트", description = "프로젝트 관리 API")
 public interface ProjectApi {
 
     @Operation(

--- a/src/main/java/com/workhub/project/dto/ProjectHistorySnapshot.java
+++ b/src/main/java/com/workhub/project/dto/ProjectHistorySnapshot.java
@@ -13,7 +13,8 @@ public record ProjectHistorySnapshot(
         String projectDescription,
         Status status,
         LocalDate contractStartDate,
-        LocalDate contractEndDate
+        LocalDate contractEndDate,
+        Long company
 ) {
     public static  ProjectHistorySnapshot from(Project project) {
         return ProjectHistorySnapshot.builder()
@@ -23,6 +24,7 @@ public record ProjectHistorySnapshot(
                 .status(project.getStatus())
                 .contractStartDate(project.getContractStartDate())
                 .contractEndDate(project.getContractEndDate())
+                .company(project.getClientCompanyId())
                 .build();
     }
 }

--- a/src/main/java/com/workhub/project/dto/ProjectResponse.java
+++ b/src/main/java/com/workhub/project/dto/ProjectResponse.java
@@ -13,7 +13,8 @@ public record ProjectResponse(
         String projectDescription,
         Status status,
         LocalDate contractStartDate,
-        LocalDate contractEndDate
+        LocalDate contractEndDate,
+        Long company
 ) {
     public static ProjectResponse from(Project project) {
         return ProjectResponse.builder()
@@ -23,6 +24,7 @@ public record ProjectResponse(
                 .status(project.getStatus())
                 .contractStartDate(project.getContractStartDate())
                 .contractEndDate(project.getContractEndDate())
+                .company(project.getClientCompanyId())
                 .build();
     }
 }

--- a/src/main/java/com/workhub/project/service/UpdateProjectService.java
+++ b/src/main/java/com/workhub/project/service/UpdateProjectService.java
@@ -50,49 +50,12 @@ public class UpdateProjectService {
     public ProjectResponse updateProject(Long projectId, CreateProjectRequest request) {
 
         Project original = projectService.findProjectById(projectId);
-
-        recordFieldChangesIfNeeded(original, request);
-        original.update(request);
-
-        return ProjectResponse.from(original);
-    }
-
-    /**
-     * 필드 변경 감지 및 히스토리 기록
-     */
-    private void recordFieldChangesIfNeeded(Project original, CreateProjectRequest request) {
-
-        Long projectId = original.getProjectId();
         ProjectHistorySnapshot snapshot = ProjectHistorySnapshot.from(original);
 
-        // projectTitle 변경 체크
-        if (request.projectName() != null &&
-                !request.projectName().equals(original.getProjectTitle())) {
-        }
+        original.update(request);
+        historyRecorder.recordHistory(HistoryType.PROJECT, projectId, ActionType.UPDATE, snapshot);
 
-        // projectDescription 변경 체크
-        if (request.projectDescription() != null &&
-                !request.projectDescription().equals(original.getProjectDescription())) {
-        }
-
-        // contractStartDate 변경 체크
-        if (request.starDate() != null &&
-                !request.starDate().equals(original.getContractStartDate())) {
-        }
-
-        // contractEndDate 변경 체크
-        if (request.endDate() != null &&
-                !request.endDate().equals(original.getContractEndDate())) {
-        }
-
-        // clientCompanyId 변경 체크
-        if (request.company() != null &&
-                !request.company().equals(original.getClientCompanyId())) {
-        }
-
-        historyRecorder.recordHistory(
-                HistoryType.PROJECT, projectId, ActionType.UPDATE, snapshot
-        );
+        return ProjectResponse.from(original);
     }
 
 }

--- a/src/main/java/com/workhub/projectNode/api/ProjectNodeApi.java
+++ b/src/main/java/com/workhub/projectNode/api/ProjectNodeApi.java
@@ -1,11 +1,7 @@
 package com.workhub.projectNode.api;
 
 import com.workhub.global.response.ApiResponse;
-import com.workhub.projectNode.dto.CreateNodeRequest;
-import com.workhub.projectNode.dto.CreateNodeResponse;
-import com.workhub.projectNode.dto.NodeListResponse;
-import com.workhub.projectNode.dto.UpdateNodOrderRequest;
-import com.workhub.projectNode.dto.UpdateNodeStatusRequest;
+import com.workhub.projectNode.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -17,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Project Node", description = "프로젝트 노드 관리 API")
+@Tag(name = "프로젝트 노드", description = "프로젝트 노드 관리 API")
 public interface ProjectNodeApi {
 
     @Operation(
@@ -146,5 +142,39 @@ public interface ProjectNodeApi {
 
             @Parameter(description = "노드 순서 변경 요청 리스트 (각 노드의 ID와 새로운 순서)", required = true)
             @RequestBody List<UpdateNodOrderRequest> request
+    );
+
+    @Operation(
+            summary = "프로젝트 노드 정보 수정",
+            description = "프로젝트 노드의 내용을 수정합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "노드 정보 변경 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (필수 항목 누락, 유효하지 않은 순서 값 등)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "프로젝트 또는 노드를 찾을 수 없음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 (정보 변경 실패, 히스토리 저장 실패 등)"
+            )
+    })
+    @PutMapping("{nodeId}")
+    public ResponseEntity<ApiResponse<CreateNodeResponse>> updateNode(
+            @Parameter(description = "프로젝트 ID", required = true)
+            @PathVariable Long projectId,
+
+            @Parameter(description = "프로젝트 노드 ID", required = true)
+            @PathVariable Long nodeId,
+
+            @Parameter(description = "프로젝트 노드 수정 요청 정보", required = true)
+            @RequestBody UpdateNodeRequest request
     );
 }

--- a/src/main/java/com/workhub/projectNode/controller/ProjectNodeController.java
+++ b/src/main/java/com/workhub/projectNode/controller/ProjectNodeController.java
@@ -61,4 +61,15 @@ public class ProjectNodeController implements ProjectNodeApi {
 
         return ApiResponse.success("노드 순서 변경 성공");
     }
+
+    @Override
+    @PutMapping("{nodeId}")
+    public ResponseEntity<ApiResponse<CreateNodeResponse>> updateNode(@PathVariable Long projectId,
+                                                                      @PathVariable Long nodeId,
+                                                                      @RequestBody UpdateNodeRequest request) {
+
+        CreateNodeResponse response = updateProjectNodeService.updateNode(projectId, nodeId, request);
+
+        return ApiResponse.success(response);
+    }
 }

--- a/src/main/java/com/workhub/projectNode/dto/UpdateNodeRequest.java
+++ b/src/main/java/com/workhub/projectNode/dto/UpdateNodeRequest.java
@@ -1,0 +1,14 @@
+package com.workhub.projectNode.dto;
+
+import com.workhub.projectNode.entity.Priority;
+
+import java.time.LocalDate;
+
+public record UpdateNodeRequest(
+        String title,
+        String description,
+        LocalDate startDate,
+        LocalDate endDate,
+        Priority priority
+) {
+}

--- a/src/main/java/com/workhub/projectNode/entity/ProjectNode.java
+++ b/src/main/java/com/workhub/projectNode/entity/ProjectNode.java
@@ -2,6 +2,7 @@ package com.workhub.projectNode.entity;
 
 import com.workhub.global.entity.BaseTimeEntity;
 import com.workhub.projectNode.dto.CreateNodeRequest;
+import com.workhub.projectNode.dto.UpdateNodeRequest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -72,6 +73,24 @@ public class ProjectNode extends BaseTimeEntity {
 
     public void updateNodeOrder(Integer nodeOrder) {
         this.nodeOrder = nodeOrder;
+    }
+
+    public void update(UpdateNodeRequest request) {
+        if(request.title() != null){
+            this.title = request.title();
+        }
+        if(request.description() != null){
+            this.description = request.description();
+        }
+        if(request.startDate() != null){
+            this.contractStartDate = request.startDate();
+        }
+        if(request.endDate() != null){
+            this.contractEndDate = request.endDate();
+        }
+        if(request.priority() != null){
+            this.priority = request.priority();
+        }
     }
 
     public static ProjectNode of(Long projectId, CreateNodeRequest request, Integer nodeOrder) {

--- a/src/main/java/com/workhub/projectNode/service/UpdateProjectNodeService.java
+++ b/src/main/java/com/workhub/projectNode/service/UpdateProjectNodeService.java
@@ -6,9 +6,7 @@ import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
 import com.workhub.global.util.StatusValidator;
-import com.workhub.projectNode.dto.NodeSnapshot;
-import com.workhub.projectNode.dto.UpdateNodOrderRequest;
-import com.workhub.projectNode.dto.UpdateNodeStatusRequest;
+import com.workhub.projectNode.dto.*;
 import com.workhub.projectNode.entity.ProjectNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,6 +75,23 @@ public class UpdateProjectNodeService {
                 );
             }
         });
-
     }
+
+    /**
+     * 프로젝트 노드의 정보를 수정합니다.
+     * @param projectId 프로젝트 ID
+     * @param nodeId  노드 ID
+     * @param request  수정 요청 정보
+     */
+    public CreateNodeResponse updateNode(Long projectId, Long nodeId, UpdateNodeRequest request) {
+
+        ProjectNode original = projectNodeService.findByIdAndProjectId(nodeId, projectId);
+        NodeSnapshot snapshot = NodeSnapshot.from(original);
+
+        original.update(request);
+        historyRecorder.recordHistory(HistoryType.PROJECT_NODE, nodeId, ActionType.UPDATE,snapshot);
+
+        return CreateNodeResponse.from(original);
+    }
+    
 }

--- a/src/test/java/com/workhub/project/service/UpdateProjectServiceTest.java
+++ b/src/test/java/com/workhub/project/service/UpdateProjectServiceTest.java
@@ -137,7 +137,7 @@ class UpdateProjectServiceTest {
     }
 
     @Test
-    @DisplayName("프로젝트 정보를 정상적으로 업데이트하고 변경된 필드마다 히스토리를 기록한다")
+    @DisplayName("프로젝트 정보를 정상적으로 업데이트하고 변경 전 상태를 히스토리에 기록한다")
     void givenValidUpdateRequest_whenUpdateProject_thenSuccessAndRecordHistory() {
         // given
         Long projectId = 1L;
@@ -152,6 +152,8 @@ class UpdateProjectServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.projectTitle()).isEqualTo("수정된 프로젝트");
         assertThat(result.projectDescription()).isEqualTo("수정된 설명");
+        assertThat(result.contractStartDate()).isEqualTo(LocalDate.of(2024, 2, 1));
+        assertThat(result.contractEndDate()).isEqualTo(LocalDate.of(2024, 11, 30));
 
         assertThat(mockProject.getProjectTitle()).isEqualTo("수정된 프로젝트");
         assertThat(mockProject.getProjectDescription()).isEqualTo("수정된 설명");
@@ -161,7 +163,7 @@ class UpdateProjectServiceTest {
 
         verify(projectService).findProjectById(projectId);
 
-        // 실제 구현은 한 번만 히스토리를 기록 (변경 전 전체 스냅샷)
+        // 변경 전 전체 스냅샷을 한 번만 히스토리에 기록
         ArgumentCaptor<ProjectHistorySnapshot> snapshotCaptor = ArgumentCaptor.forClass(ProjectHistorySnapshot.class);
         verify(historyRecorder, times(1)).recordHistory(
                 eq(HistoryType.PROJECT),
@@ -172,12 +174,16 @@ class UpdateProjectServiceTest {
 
         ProjectHistorySnapshot capturedSnapshot = snapshotCaptor.getValue();
         assertThat(capturedSnapshot.projectTitle()).isEqualTo("기존 프로젝트");
+        assertThat(capturedSnapshot.projectDescription()).isEqualTo("기존 설명");
         assertThat(capturedSnapshot.status()).isEqualTo(Status.IN_PROGRESS);
+        assertThat(capturedSnapshot.contractStartDate()).isEqualTo(LocalDate.of(2024, 1, 1));
+        assertThat(capturedSnapshot.contractEndDate()).isEqualTo(LocalDate.of(2024, 12, 31));
+        assertThat(capturedSnapshot.company()).isEqualTo(100L);
     }
 
     @Test
-    @DisplayName("일부 필드만 변경 시 해당 필드만 히스토리에 기록된다")
-    void givenPartialUpdateRequest_whenUpdateProject_thenRecordOnlyChangedFields() {
+    @DisplayName("일부 필드만 변경 시에도 변경 전 전체 상태를 히스토리에 기록한다")
+    void givenPartialUpdateRequest_whenUpdateProject_thenRecordCompleteSnapshot() {
         // given
         Long projectId = 1L;
 
@@ -205,7 +211,7 @@ class UpdateProjectServiceTest {
 
         verify(projectService).findProjectById(projectId);
 
-        // 실제 구현은 변경 여부와 무관하게 한 번만 히스토리 기록
+        // 변경 전 전체 스냅샷을 한 번만 히스토리에 기록
         ArgumentCaptor<ProjectHistorySnapshot> snapshotCaptor = ArgumentCaptor.forClass(ProjectHistorySnapshot.class);
         verify(historyRecorder, times(1)).recordHistory(
                 eq(HistoryType.PROJECT),
@@ -280,8 +286,8 @@ class UpdateProjectServiceTest {
     }
 
     @Test
-    @DisplayName("프로젝트 제목만 변경 시 제목 히스토리만 기록된다")
-    void givenOnlyTitleChange_whenUpdateProject_thenRecordOnlyTitleHistory() {
+    @DisplayName("프로젝트 제목만 변경 시에도 변경 전 전체 상태를 히스토리에 기록한다")
+    void givenOnlyTitleChange_whenUpdateProject_thenRecordCompleteSnapshot() {
         // given
         Long projectId = 1L;
 
@@ -307,7 +313,7 @@ class UpdateProjectServiceTest {
 
         verify(projectService).findProjectById(projectId);
 
-        // 실제 구현은 한 번만 히스토리 기록 (변경 전 전체 스냅샷)
+        // 변경 전 전체 스냅샷을 한 번만 히스토리에 기록
         ArgumentCaptor<ProjectHistorySnapshot> snapshotCaptor = ArgumentCaptor.forClass(ProjectHistorySnapshot.class);
         verify(historyRecorder, times(1)).recordHistory(
                 eq(HistoryType.PROJECT),
@@ -321,8 +327,8 @@ class UpdateProjectServiceTest {
     }
 
     @Test
-    @DisplayName("계약 기간만 변경 시 시작일과 종료일 히스토리가 기록된다")
-    void givenOnlyDateChange_whenUpdateProject_thenRecordDateHistory() {
+    @DisplayName("계약 기간만 변경 시에도 변경 전 전체 상태를 히스토리에 기록한다")
+    void givenOnlyDateChange_whenUpdateProject_thenRecordCompleteSnapshot() {
         // given
         Long projectId = 1L;
 
@@ -348,7 +354,7 @@ class UpdateProjectServiceTest {
 
         verify(projectService).findProjectById(projectId);
 
-        // 실제 구현은 한 번만 히스토리 기록 (변경 전 전체 스냅샷)
+        // 변경 전 전체 스냅샷을 한 번만 히스토리에 기록
         ArgumentCaptor<ProjectHistorySnapshot> snapshotCaptor = ArgumentCaptor.forClass(ProjectHistorySnapshot.class);
         verify(historyRecorder, times(1)).recordHistory(
                 eq(HistoryType.PROJECT),
@@ -363,8 +369,8 @@ class UpdateProjectServiceTest {
     }
 
     @Test
-    @DisplayName("고객사만 변경 시 고객사 ID 히스토리가 기록된다")
-    void givenOnlyCompanyChange_whenUpdateProject_thenRecordCompanyHistory() {
+    @DisplayName("고객사만 변경 시에도 변경 전 전체 상태를 히스토리에 기록한다")
+    void givenOnlyCompanyChange_whenUpdateProject_thenRecordCompleteSnapshot() {
         // given
         Long projectId = 1L;
 
@@ -389,7 +395,7 @@ class UpdateProjectServiceTest {
 
         verify(projectService).findProjectById(projectId);
 
-        // 실제 구현은 한 번만 히스토리 기록 (변경 전 전체 스냅샷)
+        // 변경 전 전체 스냅샷을 한 번만 히스토리에 기록
         ArgumentCaptor<ProjectHistorySnapshot> snapshotCaptor = ArgumentCaptor.forClass(ProjectHistorySnapshot.class);
         verify(historyRecorder, times(1)).recordHistory(
                 eq(HistoryType.PROJECT),
@@ -398,8 +404,48 @@ class UpdateProjectServiceTest {
                 snapshotCaptor.capture()
         );
 
-        // 변경 전 스냅샷에는 기존 고객사 ID가 포함되어 있지 않음 (ProjectHistorySnapshot에 clientCompanyId 필드 없음)
         ProjectHistorySnapshot capturedSnapshot = snapshotCaptor.getValue();
         assertThat(capturedSnapshot.projectTitle()).isEqualTo("기존 프로젝트");
+        assertThat(capturedSnapshot.company()).isEqualTo(100L); // 변경 전 고객사 ID
+    }
+
+    @Test
+    @DisplayName("프로젝트 업데이트 시 모든 메서드가 순차적으로 호출된다")
+    void givenUpdateRequest_whenUpdateProject_thenAllMethodsCalledInOrder() {
+        // given
+        Long projectId = 1L;
+
+        when(projectService.findProjectById(projectId)).thenReturn(mockProject);
+        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
+
+        // when
+        updateProjectService.updateProject(projectId, updateRequest);
+
+        // then
+        var inOrder = inOrder(projectService, historyRecorder);
+        inOrder.verify(projectService).findProjectById(projectId);
+        inOrder.verify(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
+    }
+
+    @Test
+    @DisplayName("프로젝트 업데이트 후 반환된 응답에 모든 필드가 포함된다")
+    void givenUpdateRequest_whenUpdateProject_thenReturnCompleteResponse() {
+        // given
+        Long projectId = 1L;
+
+        when(projectService.findProjectById(projectId)).thenReturn(mockProject);
+        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
+
+        // when
+        ProjectResponse result = updateProjectService.updateProject(projectId, updateRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.projectId()).isEqualTo(projectId);
+        assertThat(result.projectTitle()).isEqualTo("수정된 프로젝트");
+        assertThat(result.projectDescription()).isEqualTo("수정된 설명");
+        assertThat(result.status()).isEqualTo(Status.IN_PROGRESS);
+        assertThat(result.contractStartDate()).isEqualTo(LocalDate.of(2024, 2, 1));
+        assertThat(result.contractEndDate()).isEqualTo(LocalDate.of(2024, 11, 30));
     }
 }


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
> 주요 파일, 로직, 컴포넌트 등을 구체적으로 적어주세요.

src/main/java/com/workhub/project/service/UpdateProjectService.java 
- 프로젝트 정보 수정 시 변경 전 상태를 스냅샷으로 히스토리에 저장하도록 수정했습니다.

---

## 체크리스트

### 코드 품질
- [ ] 코드가 정상적으로 빌드됩니다.
- [ ] 로컬 테스트를 통과했습니다.
- [ ] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [ ] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [ ] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [ ] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [ ] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
