### PR TITLE
feat: 댓글 CRUD, history

### DIFF
--- a/src/main/java/com/workhub/post/api/CommentApi.java
+++ b/src/main/java/com/workhub/post/api/CommentApi.java
@@ -1,0 +1,93 @@
+package com.workhub.post.api;
+
+import com.workhub.global.response.ApiResponse;
+import com.workhub.post.dto.comment.request.CommentRequest;
+import com.workhub.post.dto.comment.request.CommentUpdateRequest;
+import com.workhub.post.dto.comment.response.CommentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Comment", description = "게시글 댓글 API")
+@RequestMapping("/api/v1/projects/{projectId}/nodes/{nodeId}/posts/{postId}/comments")
+public interface CommentApi {
+
+    @Operation(
+            summary = "댓글 목록 조회",
+            description = "게시글에 달린 댓글 목록을 계층 구조로 조회합니다.",
+            parameters = {
+                    @Parameter(name = "projectId", in = ParameterIn.PATH, description = "프로젝트 식별자", required = true),
+                    @Parameter(name = "nodeId", in = ParameterIn.PATH, description = "노드 식별자", required = true),
+                    @Parameter(name = "postId", in = ParameterIn.PATH, description = "게시글 식별자", required = true)
+            }
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 목록 조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CommentResponse.class))
+            )
+    })
+    @GetMapping
+    ResponseEntity<ApiResponse<Page<CommentResponse>>> readComments(
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @PathVariable Long postId,
+            @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    );
+
+    @Operation(
+            summary = "댓글 작성",
+            description = "게시글에 댓글을 작성합니다."
+    )
+    @PostMapping
+    ResponseEntity<ApiResponse<CommentResponse>> create(
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentRequest request,
+            @AuthenticationPrincipal com.workhub.global.security.CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "댓글 수정",
+            description = "댓글 내용을 수정합니다."
+    )
+    @PatchMapping("/{commentId}")
+    ResponseEntity<ApiResponse<CommentResponse>> update(
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequest request,
+            @AuthenticationPrincipal com.workhub.global.security.CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "댓글 삭제",
+            description = "댓글을 삭제합니다."
+    )
+    @DeleteMapping("/{commentId}")
+    ResponseEntity<ApiResponse<Long>> delete(
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal com.workhub.global.security.CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/com/workhub/post/controller/CommentController.java
+++ b/src/main/java/com/workhub/post/controller/CommentController.java
@@ -1,0 +1,134 @@
+package com.workhub.post.controller;
+
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.global.response.ApiResponse;
+import com.workhub.post.api.CommentApi;
+import com.workhub.post.dto.comment.request.CommentRequest;
+import com.workhub.post.dto.comment.request.CommentUpdateRequest;
+import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.global.security.CustomUserDetails;
+import com.workhub.post.service.comment.CreateCommentService;
+import com.workhub.post.service.comment.DeleteCommentService;
+import com.workhub.post.service.comment.ReadCommentService;
+import com.workhub.post.service.comment.UpdateCommentService;
+import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/projects/{projectId}/nodes/{nodeId}/posts/{postId}/comments")
+public class CommentController implements CommentApi {
+
+    private final CreateCommentService createCommentService;
+    private final ReadCommentService readCommentService;
+    private final UpdateCommentService updateCommentService;
+    private final DeleteCommentService deleteCommentService;
+
+    /**
+     * 댓글 목록을 계층 구조로 조회한다.
+     *
+     * @param projectId 프로젝트 식별자
+     * @param nodeId    노드 식별자
+     * @param postId    게시글 식별자
+     * @param pageable  페이지 정보
+     * @return 댓글 목록 페이지 응답
+     */
+    @Override
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<ApiResponse<Page<CommentResponse>>> readComments(
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @PathVariable Long postId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<CommentResponse> comments = readCommentService.findComment(projectId, postId, pageable);
+        return ApiResponse.success(comments, "댓글 목록 조회에 성공했습니다.");
+    }
+
+    /**
+     * 댓글을 작성한다.
+     *
+     * @param projectId 프로젝트 식별자
+     * @param nodeId    노드 식별자
+     * @param postId    게시글 식별자
+     * @param request   작성 요청 본문
+     * @param userDetails 인증 정보
+     * @return 생성된 댓글 정보
+     */
+    @Override
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<ApiResponse<CommentResponse>> create(
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        CommentResponse response = createCommentService.create(projectId, postId, getUserId(userDetails), request);
+        return ApiResponse.created(response, "댓글 작성에 성공했습니다.");
+    }
+
+    /**
+     * 댓글을 수정한다.
+     *
+     * @param projectId 프로젝트 식별자
+     * @param nodeId    노드 식별자
+     * @param postId    게시글 식별자
+     * @param commentId 댓글 식별자
+     * @param request   수정 요청 본문
+     * @param userDetails 인증 정보
+     * @return 수정된 댓글 정보
+     */
+    @Override
+    @PatchMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<ApiResponse<CommentResponse>> update(
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        CommentResponse response = updateCommentService.update(commentId, postId, getUserId(userDetails), request);
+        return ApiResponse.success(response, "댓글 수정에 성공했습니다.");
+    }
+
+    /**
+     * 댓글을 삭제한다.
+     *
+     * @param projectId 프로젝트 식별자
+     * @param nodeId    노드 식별자
+     * @param postId    게시글 식별자
+     * @param commentId 댓글 식별자
+     * @param userDetails 인증 정보
+     * @return 삭제된 댓글 ID
+     */
+    @Override
+    @DeleteMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<ApiResponse<Long>> delete(
+            @PathVariable Long projectId,
+            @PathVariable Long nodeId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long result = deleteCommentService.delete(projectId, postId, commentId, getUserId(userDetails));
+        return ApiResponse.success(result, "댓글 삭제에 성공했습니다.");
+    }
+
+    private Long getUserId(CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new BusinessException(ErrorCode.NOT_LOGGED_IN);
+        }
+        return userDetails.getUserId();
+    }
+}

--- a/src/main/java/com/workhub/post/dto/comment/CommentHistorySnapshot.java
+++ b/src/main/java/com/workhub/post/dto/comment/CommentHistorySnapshot.java
@@ -1,0 +1,17 @@
+package com.workhub.post.dto.comment;
+
+import com.workhub.post.entity.PostComment;
+
+/**
+ * 댓글 변경 이력을 위한 스냅샷.
+ */
+public record CommentHistorySnapshot(String content, Long postId, Long parentCommentId, Long userId) {
+    public static CommentHistorySnapshot from(PostComment comment) {
+        return new CommentHistorySnapshot(
+                comment.getContent(),
+                comment.getPostId(),
+                comment.getParentCommentId(),
+                comment.getUserId()
+        );
+    }
+}

--- a/src/main/java/com/workhub/post/dto/comment/request/CommentRequest.java
+++ b/src/main/java/com/workhub/post/dto/comment/request/CommentRequest.java
@@ -1,0 +1,9 @@
+package com.workhub.post.dto.comment.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CommentRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        String content,
+        Long parentCommentId
+        ) { }

--- a/src/main/java/com/workhub/post/dto/comment/request/CommentUpdateRequest.java
+++ b/src/main/java/com/workhub/post/dto/comment/request/CommentUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.workhub.post.dto.comment.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentUpdateRequest(
+        @NotBlank(message = "내용은 필수입니다.")
+        @Size(max = 1000, message = "내용은 1000자를 초과할 수 없습니다.")
+        String commentContext
+        ) {
+}

--- a/src/main/java/com/workhub/post/dto/comment/response/CommentResponse.java
+++ b/src/main/java/com/workhub/post/dto/comment/response/CommentResponse.java
@@ -1,0 +1,44 @@
+package com.workhub.post.dto.comment.response;
+
+import com.workhub.post.entity.PostComment;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public record CommentResponse(
+        Long commentId,
+        Long postId,
+        Long userId,
+        Long parentCommentId,
+        String commentContent,
+        LocalDateTime createAt,
+        LocalDateTime updateAt,
+        List<CommentResponse> children
+) {
+    public static CommentResponse from(PostComment comment){
+        return new CommentResponse(
+                comment.getCommentId(),
+                comment.getPostId(),
+                comment.getUserId(),
+                comment.getParentCommentId(),
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt(),
+                new ArrayList<>()
+        );
+    }
+
+    public CommentResponse withChildren(List<CommentResponse> children){
+        return new CommentResponse(
+                commentId,
+                postId,
+                userId,
+                parentCommentId,
+                commentContent,
+                createAt,
+                updateAt,
+                children
+        );
+    }
+}

--- a/src/main/java/com/workhub/post/entity/PostHistory.java
+++ b/src/main/java/com/workhub/post/entity/PostHistory.java
@@ -2,11 +2,14 @@ package com.workhub.post.entity;
 
 import com.workhub.global.entity.ActionType;
 import com.workhub.global.entity.BaseHistoryEntity;
+import com.workhub.global.util.SecurityUtil;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
 
 @Getter
 @SuperBuilder
@@ -21,6 +24,10 @@ public class PostHistory extends BaseHistoryEntity {
                 .actionType(actionType)
                 .beforeData(beforeData)
                 .createdBy(creator)
+                .updatedBy(SecurityUtil.getCurrentUserIdOrThrow())
+                .updatedAt(LocalDateTime.now())
+                .ipAddress(SecurityUtil.getRemoteAddr().orElse(null))
+                .userAgent(SecurityUtil.getUserAgent().orElse(null))
                 .build();
     }
 }

--- a/src/main/java/com/workhub/post/handler/CommentHistoryHandler.java
+++ b/src/main/java/com/workhub/post/handler/CommentHistoryHandler.java
@@ -1,0 +1,21 @@
+package com.workhub.post.handler;
+
+import com.workhub.global.entity.HistoryType;
+import com.workhub.global.history.HistoryHandler;
+import com.workhub.post.entity.CommentHistory;
+import com.workhub.post.repository.comment.CommentHistoryRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentHistoryHandler extends HistoryHandler {
+
+    public CommentHistoryHandler(CommentHistoryRepository repository) {
+        super(repository, CommentHistory::of);
+    }
+
+    @Override
+    public HistoryType getType() {
+        return HistoryType.POST_COMMENT;
+    }
+}
+

--- a/src/main/java/com/workhub/post/repository/comment/CommentHistoryRepository.java
+++ b/src/main/java/com/workhub/post/repository/comment/CommentHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.workhub.post.repository.comment;
+
+import com.workhub.global.repository.BaseHistoryRepository;
+import com.workhub.post.entity.CommentHistory;
+
+public interface CommentHistoryRepository extends BaseHistoryRepository<CommentHistory> {
+}

--- a/src/main/java/com/workhub/post/repository/comment/CommentRepository.java
+++ b/src/main/java/com/workhub/post/repository/comment/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.workhub.post.repository.comment;
+
+import com.workhub.post.entity.PostComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<PostComment, Long>, CommentRepositoryCustom {
+    List<PostComment> findByParentCommentId(Long parentCommentId);
+}

--- a/src/main/java/com/workhub/post/repository/comment/CommentRepositoryCustom.java
+++ b/src/main/java/com/workhub/post/repository/comment/CommentRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.workhub.post.repository.comment;
+
+import com.workhub.post.entity.PostComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+    Page<PostComment> findByPostWithReplies(Long postId, Pageable pageable);
+
+    List<PostComment> findAllByPostId(Long postId);
+}

--- a/src/main/java/com/workhub/post/repository/comment/CommentRepositoryImpl.java
+++ b/src/main/java/com/workhub/post/repository/comment/CommentRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.workhub.post.repository.comment;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.workhub.post.entity.PostComment;
+import com.workhub.post.entity.QPostComment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<PostComment> findByPostWithReplies(Long postId, Pageable pageable) {
+        QPostComment postComment = QPostComment.postComment;
+
+        // 최상위 댓글만 페이징하여 조회
+        List<PostComment> topLevelComments = queryFactory
+                .selectFrom(postComment)
+                .where(
+                        postIdEq(postId),
+                        postComment.parentCommentId.isNull()
+                )
+                .orderBy(postComment.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 최상위 댓글의 총 개수
+        Long total = queryFactory
+                .select(postComment.count())
+                .from(postComment)
+                .where(
+                        postIdEq(postId),
+                        postComment.parentCommentId.isNull()
+                )
+                .fetchOne();
+
+        return new PageImpl<>(topLevelComments, pageable, total == null ? 0 : total);
+    }
+
+    @Override
+    public List<PostComment> findAllByPostId(Long postId) {
+        QPostComment postComment = QPostComment.postComment;
+
+        return queryFactory
+                .selectFrom(postComment)
+                .where(postIdEq(postId))
+                .orderBy(postComment.createdAt.asc())
+                .fetch();
+    }
+
+    private BooleanExpression postIdEq(Long postId) {
+        return postId == null ? null : QPostComment.postComment.postId.eq(postId);
+    }
+}

--- a/src/main/java/com/workhub/post/service/comment/CommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/CommentService.java
@@ -23,7 +23,7 @@ public class CommentService {
 
     public PostComment findById(Long commentId) {
         return commentRepository.findById(commentId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXISTS_CS_QNA));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXISTS_COMMENT));
 
     }
 

--- a/src/main/java/com/workhub/post/service/comment/CommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/CommentService.java
@@ -1,0 +1,49 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.post.entity.PostComment;
+import com.workhub.post.repository.comment.CommentRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+    private final CommentRepository commentRepository;
+
+    public PostComment save(PostComment postComment){return commentRepository.save(postComment);}
+
+    public PostComment findById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXISTS_CS_QNA));
+
+    }
+
+    public PostComment findByCommentAndMatchedUserId(Long commentId, Long userId) {
+        PostComment comment = findById(commentId);
+        if (!Objects.equals(comment.getUserId(), userId)) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_COMMENT_POST);
+        }
+        return comment;
+    }
+
+    public List<PostComment> findAllByPostId(Long postId) {
+        return commentRepository.findAllByPostId(postId);
+    }
+
+    public Page<PostComment> findPostWithReplies(Long postId, Pageable pageable) {
+        return commentRepository.findByPostWithReplies(postId, pageable);
+    }
+
+    public List<PostComment> findByParentCommentId(Long parentCommentId) {
+        return commentRepository.findByParentCommentId(parentCommentId);
+    }
+}

--- a/src/main/java/com/workhub/post/service/comment/CreateCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/CreateCommentService.java
@@ -1,0 +1,65 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.global.entity.ActionType;
+import com.workhub.global.entity.HistoryType;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.request.CommentRequest;
+import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.post.entity.PostComment;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateCommentService {
+    private final CommentService commentService;
+    private final HistoryRecorder historyRecorder;
+
+    /**
+     * 댓글을 생성하고 히스토리를 기록한다.
+     *
+     * @param projectId 프로젝트 식별자
+     * @param postId 게시글 식별자
+     * @param userId 작성자 식별자
+     * @param commentRequest 생성 요청 본문
+     * @return 생성된 댓글 응답
+     */
+    public CommentResponse create(Long projectId, Long postId, Long userId, CommentRequest commentRequest) {
+        validateContent(commentRequest.content());
+
+        Long parentCommentId = resolveParent(postId, commentRequest.parentCommentId());
+        PostComment postComment = PostComment.of(postId, userId, parentCommentId, commentRequest.content());
+        postComment =  commentService.save(postComment);
+
+        historyRecorder.recordHistory(HistoryType.POST, postComment.getCommentId(), ActionType.CREATE, postComment.getContent());
+        return CommentResponse.from(postComment);
+    }
+
+    /**
+     * 댓글 본문 유효성을 검증한다.
+     */
+    private void validateContent(String content){
+        if ((content == null) || content.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_COMMENT_CONTENT);
+        }
+    }
+
+    /**
+     * 부모 댓글 존재 여부와 동일 게시글 여부를 검증한다.
+     */
+    private Long resolveParent(Long postId, Long parentCommentId) {
+        if (parentCommentId == null) {
+            return null;
+        }
+
+        PostComment parent = commentService.findById(postId);
+        if (!postId.equals(parent.getPostId())) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_COMMENT_POST);
+        }
+        return parent.getPostId();
+    }
+}

--- a/src/main/java/com/workhub/post/service/comment/CreateCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/CreateCommentService.java
@@ -5,6 +5,7 @@ import com.workhub.global.entity.HistoryType;
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.dto.comment.request.CommentRequest;
 import com.workhub.post.dto.comment.response.CommentResponse;
 import com.workhub.post.entity.PostComment;
@@ -35,7 +36,7 @@ public class CreateCommentService {
         PostComment postComment = PostComment.of(postId, userId, parentCommentId, commentRequest.content());
         postComment =  commentService.save(postComment);
 
-        historyRecorder.recordHistory(HistoryType.POST, postComment.getCommentId(), ActionType.CREATE, postComment.getContent());
+        snapshotAndRecordHistory(postComment, ActionType.CREATE);
         return CommentResponse.from(postComment);
     }
 
@@ -56,10 +57,18 @@ public class CreateCommentService {
             return null;
         }
 
-        PostComment parent = commentService.findById(postId);
+        PostComment parent = commentService.findById(parentCommentId);
         if (!postId.equals(parent.getPostId())) {
             throw new BusinessException(ErrorCode.NOT_MATCHED_COMMENT_POST);
         }
-        return parent.getPostId();
+        return parent.getCommentId();
+    }
+
+    /**
+     * 댓글을 스냅샷으로 변환해 히스토리에 저장한다.
+     */
+    private void snapshotAndRecordHistory(PostComment comment, ActionType actionType) {
+        CommentHistorySnapshot snapshot = CommentHistorySnapshot.from(comment);
+        historyRecorder.recordHistory(HistoryType.POST_COMMENT, comment.getCommentId(), actionType, snapshot);
     }
 }

--- a/src/main/java/com/workhub/post/service/comment/DeleteCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/DeleteCommentService.java
@@ -5,6 +5,7 @@ import com.workhub.global.entity.HistoryType;
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.entity.PostComment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -53,8 +54,13 @@ public class DeleteCommentService {
         for (PostComment child : children) {
             deleteWithChildren(child);
         }
-        historyRecorder.recordHistory(HistoryType.POST, comment.getCommentId(), ActionType.DELETE, comment.getContent());
+        snapshotAndRecordHistory(comment, ActionType.DELETE);
 
         comment.markDeleted();
+    }
+
+    private void snapshotAndRecordHistory(PostComment comment, ActionType actionType) {
+        CommentHistorySnapshot snapshot = CommentHistorySnapshot.from(comment);
+        historyRecorder.recordHistory(HistoryType.POST_COMMENT, comment.getCommentId(), actionType, snapshot);
     }
 }

--- a/src/main/java/com/workhub/post/service/comment/DeleteCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/DeleteCommentService.java
@@ -1,0 +1,60 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.global.entity.ActionType;
+import com.workhub.global.entity.HistoryType;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.entity.PostComment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteCommentService {
+    private final CommentService commentService;
+    private final HistoryRecorder historyRecorder;
+
+    /**
+     * 댓글과 자식 댓글을 삭제(소프트 딜리트)하고 히스토리를 기록한다.
+     *
+     * @param projectId 프로젝트 식별자
+     * @param postId 게시글 식별자
+     * @param commentId 댓글 식별자
+     * @param userId 사용자 식별자
+     * @return 삭제된 댓글의 게시글 ID
+     */
+    public Long delete(Long projectId, Long postId, Long commentId, Long userId) {
+        PostComment postComment = commentService.findByCommentAndMatchedUserId(commentId, userId);
+
+        if (!postId.equals(postComment.getPostId())) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_COMMENT_POST);
+        }
+
+        if (postComment.isDeleted()) {
+            throw new BusinessException(ErrorCode.ALREADY_DELETED_POST);
+        }
+
+        deleteWithChildren(postComment);
+
+        return postComment.getPostId();
+    }
+
+    /**
+     * 자식 댓글까지 재귀적으로 삭제 처리한다.
+     */
+    private void deleteWithChildren(PostComment comment) {
+        List<PostComment> children = commentService.findByParentCommentId(comment.getCommentId());
+
+        for (PostComment child : children) {
+            deleteWithChildren(child);
+        }
+        historyRecorder.recordHistory(HistoryType.POST, comment.getCommentId(), ActionType.DELETE, comment.getContent());
+
+        comment.markDeleted();
+    }
+}

--- a/src/main/java/com/workhub/post/service/comment/ReadCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/ReadCommentService.java
@@ -1,0 +1,72 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.post.entity.PostComment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadCommentService {
+    private final CommentService commentService;
+
+    public Page<CommentResponse> findComment(Long projectId, Long postId, Pageable pageable) {
+        List<PostComment> allComments = commentService.findAllByPostId(postId);
+
+        Page<PostComment> topLevelComments = commentService.findPostWithReplies(postId, pageable);
+
+        List<CommentResponse> hierarchicalComments = buildHierarchy(
+                topLevelComments.getContent(),
+                allComments
+        );
+
+        return new PageImpl<>(
+                hierarchicalComments,
+                pageable,
+                topLevelComments.getTotalElements()
+        );
+    }
+
+    /**
+     * 댓글 목록을 계층 구조로 변환한다.
+     * @param topLevelComments 최상위 댓글 목록
+     * @param allComments 모든 댓글 목록 (부모 + 자식)
+     * @return 계층 구조로 구성된 댓글 목록
+     */
+    private List<CommentResponse> buildHierarchy(List<PostComment> topLevelComments, List<PostComment> allComments) {
+        Map<Long, List<PostComment>> childrenMap = allComments.stream()
+                .filter(comment -> comment.getParentCommentId() != null)
+                .collect(Collectors.groupingBy(PostComment::getParentCommentId));
+
+        return topLevelComments.stream()
+                .map(parent -> buildCommentWithChildren(parent, childrenMap))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 재귀적으로 댓글과 그 자식 댓글들을 구성한다.
+     * @param postComment 현재 댓글
+     * @param childrenMap 부모 ID를 키로 하는 자식 댓글 맵
+     * @return 자식 댓글을 포함한 CsQnaResponse
+     */
+    private CommentResponse buildCommentWithChildren(PostComment postComment, Map<Long, List<PostComment>> childrenMap) {
+        List<PostComment> children = childrenMap.getOrDefault(postComment.getCommentId(), new ArrayList<>());
+
+        List<CommentResponse> childResponses = children.stream()
+                .map(child -> buildCommentWithChildren(child, childrenMap))
+                .collect(Collectors.toList());
+
+        return CommentResponse.from(postComment).withChildren(childResponses);
+    }
+
+}

--- a/src/main/java/com/workhub/post/service/comment/UpdateCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/UpdateCommentService.java
@@ -5,6 +5,7 @@ import com.workhub.global.entity.HistoryType;
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.dto.comment.request.CommentUpdateRequest;
 import com.workhub.post.dto.comment.response.CommentResponse;
 import com.workhub.post.entity.PostComment;
@@ -33,7 +34,7 @@ public class UpdateCommentService {
 
         validateCommentBelongs(postComment, postId);
 
-        historyRecorder.recordHistory(HistoryType.POST, postComment.getCommentId(), ActionType.UPDATE, postComment.getContent());
+        snapshotAndRecordHistory(postComment, ActionType.UPDATE);
 
         postComment.updateContent(commentUpdateRequest.commentContext());
         return CommentResponse.from(postComment);
@@ -47,5 +48,10 @@ public class UpdateCommentService {
             throw new BusinessException(ErrorCode.NOT_MATCHED_COMMENT_POST);
         }
 
+    }
+
+    private void snapshotAndRecordHistory(PostComment comment, ActionType actionType) {
+        CommentHistorySnapshot snapshot = CommentHistorySnapshot.from(comment);
+        historyRecorder.recordHistory(HistoryType.POST_COMMENT, comment.getCommentId(), actionType, snapshot);
     }
 }

--- a/src/main/java/com/workhub/post/service/comment/UpdateCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/UpdateCommentService.java
@@ -1,0 +1,51 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.global.entity.ActionType;
+import com.workhub.global.entity.HistoryType;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.request.CommentUpdateRequest;
+import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.post.entity.PostComment;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateCommentService {
+    private final CommentService commentService;
+    private final HistoryRecorder historyRecorder;
+
+    /**
+     * 댓글을 수정하고 변경 전 내용을 히스토리에 저장한다.
+     *
+     * @param postCommentId 댓글 식별자
+     * @param postId 게시글 식별자
+     * @param userId 작성자 식별자
+     * @param commentUpdateRequest 수정 요청 본문
+     * @return 수정된 댓글 응답
+     */
+    public CommentResponse update(Long postCommentId, Long postId, Long userId, CommentUpdateRequest commentUpdateRequest) {
+        PostComment postComment = commentService.findByCommentAndMatchedUserId(postCommentId, userId);
+
+        validateCommentBelongs(postComment, postId);
+
+        historyRecorder.recordHistory(HistoryType.POST, postComment.getCommentId(), ActionType.UPDATE, postComment.getContent());
+
+        postComment.updateContent(commentUpdateRequest.commentContext());
+        return CommentResponse.from(postComment);
+    }
+
+    /**
+     * 댓글이 요청한 게시글에 속하는지 검증한다.
+     */
+    public void validateCommentBelongs(PostComment postComment, Long postId) {
+        if (!postComment.getPostId().equals(postId)) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_COMMENT_POST);
+        }
+
+    }
+}

--- a/src/test/java/com/workhub/post/service/comment/CreateCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/CreateCommentServiceTest.java
@@ -5,6 +5,7 @@ import com.workhub.global.entity.HistoryType;
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.dto.comment.request.CommentRequest;
 import com.workhub.post.dto.comment.response.CommentResponse;
 import com.workhub.post.entity.PostComment;
@@ -48,7 +49,7 @@ class CreateCommentServiceTest {
     void create_withMismatchedParent_shouldThrow() {
         CommentRequest request = new CommentRequest("hello", 99L);
         // resolveParent가 현재 postId로 조회하므로 postId와 다른 게시글을 리턴시켜 불일치 유발
-        given(commentService.findById(2L)).willReturn(mockComment(5L, 10L, null, "parent"));
+        given(commentService.findById(99L)).willReturn(mockComment(5L, 10L, null, "parent"));
 
         assertThatThrownBy(() -> createCommentService.create(1L, 2L, 3L, request))
                 .isInstanceOf(BusinessException.class)
@@ -66,10 +67,10 @@ class CreateCommentServiceTest {
 
         assertThat(response.commentId()).isEqualTo(10L);
         verify(historyRecorder).recordHistory(
-                eq(HistoryType.POST),
+                eq(HistoryType.POST_COMMENT),
                 eq(10L),
                 eq(ActionType.CREATE),
-                eq("hello")
+                eq(CommentHistorySnapshot.from(saved))
         );
     }
 

--- a/src/test/java/com/workhub/post/service/comment/CreateCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/CreateCommentServiceTest.java
@@ -1,0 +1,85 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.global.entity.ActionType;
+import com.workhub.global.entity.HistoryType;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.request.CommentRequest;
+import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.post.entity.PostComment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CreateCommentServiceTest {
+
+    @Mock
+    CommentService commentService;
+    @Mock
+    HistoryRecorder historyRecorder;
+
+    @InjectMocks
+    CreateCommentService createCommentService;
+
+    @Test
+    @DisplayName("내용이 비어 있으면 예외를 던진다")
+    void create_withBlankContent_shouldThrow() {
+        CommentRequest request = new CommentRequest("   ", null);
+
+        assertThatThrownBy(() -> createCommentService.create(1L, 2L, 3L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_COMMENT_CONTENT);
+    }
+
+    @Test
+    @DisplayName("부모 댓글의 게시글이 다르면 예외를 던진다")
+    void create_withMismatchedParent_shouldThrow() {
+        CommentRequest request = new CommentRequest("hello", 99L);
+        // resolveParent가 현재 postId로 조회하므로 postId와 다른 게시글을 리턴시켜 불일치 유발
+        given(commentService.findById(2L)).willReturn(mockComment(5L, 10L, null, "parent"));
+
+        assertThatThrownBy(() -> createCommentService.create(1L, 2L, 3L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_MATCHED_COMMENT_POST);
+    }
+
+    @Test
+    @DisplayName("정상 생성 시 댓글과 히스토리를 반환/기록한다")
+    void create_success() {
+        CommentRequest request = new CommentRequest("hello", null);
+        PostComment saved = mockComment(10L, 2L, null, "hello");
+        given(commentService.save(any(PostComment.class))).willReturn(saved);
+
+        CommentResponse response = createCommentService.create(1L, 2L, 3L, request);
+
+        assertThat(response.commentId()).isEqualTo(10L);
+        verify(historyRecorder).recordHistory(
+                eq(HistoryType.POST),
+                eq(10L),
+                eq(ActionType.CREATE),
+                eq("hello")
+        );
+    }
+
+    private PostComment mockComment(Long commentId, Long postId, Long parentId, String content) {
+        return PostComment.builder()
+                .commentId(commentId)
+                .postId(postId)
+                .parentCommentId(parentId)
+                .userId(3L)
+                .content(content)
+                .build();
+    }
+}

--- a/src/test/java/com/workhub/post/service/comment/DeleteCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/DeleteCommentServiceTest.java
@@ -1,0 +1,86 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.global.entity.ActionType;
+import com.workhub.global.entity.HistoryType;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.entity.PostComment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteCommentServiceTest {
+
+    @Mock
+    CommentService commentService;
+    @Mock
+    HistoryRecorder historyRecorder;
+
+    @InjectMocks
+    DeleteCommentService deleteCommentService;
+
+    @Test
+    @DisplayName("다른 게시글 댓글이면 삭제 시 예외를 던진다")
+    void delete_withMismatchedPost_shouldThrow() {
+        PostComment comment = mockComment(1L, 2L, "content");
+        given(commentService.findByCommentAndMatchedUserId(1L, 3L)).willReturn(comment);
+
+        assertThatThrownBy(() -> deleteCommentService.delete(10L, 99L, 1L, 3L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_MATCHED_COMMENT_POST);
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 댓글이면 예외를 던진다")
+    void delete_alreadyDeleted_shouldThrow() {
+        PostComment comment = mockComment(1L, 2L, "content");
+        comment.markDeleted();
+        given(commentService.findByCommentAndMatchedUserId(1L, 3L)).willReturn(comment);
+
+        assertThatThrownBy(() -> deleteCommentService.delete(10L, 2L, 1L, 3L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_DELETED_POST);
+    }
+
+    @Test
+    @DisplayName("정상 삭제 시 자식까지 삭제하며 히스토리가 기록된다")
+    void delete_success() {
+        PostComment comment = mockComment(1L, 2L, "content");
+        given(commentService.findByCommentAndMatchedUserId(1L, 3L)).willReturn(comment);
+        given(commentService.findByParentCommentId(anyLong())).willReturn(Collections.emptyList());
+
+        Long result = deleteCommentService.delete(10L, 2L, 1L, 3L);
+
+        assertThat(result).isEqualTo(2L);
+        assertThat(comment.isDeleted()).isTrue();
+        verify(historyRecorder).recordHistory(
+                eq(HistoryType.POST),
+                eq(1L),
+                eq(ActionType.DELETE),
+                eq("content")
+        );
+    }
+
+    private PostComment mockComment(Long commentId, Long postId, String content) {
+        return PostComment.builder()
+                .commentId(commentId)
+                .postId(postId)
+                .userId(3L)
+                .content(content)
+                .build();
+    }
+}

--- a/src/test/java/com/workhub/post/service/comment/DeleteCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/DeleteCommentServiceTest.java
@@ -5,6 +5,7 @@ import com.workhub.global.entity.HistoryType;
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.entity.PostComment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -68,10 +69,10 @@ class DeleteCommentServiceTest {
         assertThat(result).isEqualTo(2L);
         assertThat(comment.isDeleted()).isTrue();
         verify(historyRecorder).recordHistory(
-                eq(HistoryType.POST),
+                eq(HistoryType.POST_COMMENT),
                 eq(1L),
                 eq(ActionType.DELETE),
-                eq("content")
+                eq(CommentHistorySnapshot.from(comment))
         );
     }
 

--- a/src/test/java/com/workhub/post/service/comment/ReadCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/ReadCommentServiceTest.java
@@ -1,0 +1,61 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.post.entity.PostComment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ReadCommentServiceTest {
+
+    @Mock
+    CommentService commentService;
+
+    @InjectMocks
+    ReadCommentService readCommentService;
+
+    @Test
+    @DisplayName("최상위 댓글과 자식 댓글을 계층 구조로 반환한다")
+    void findComment_buildHierarchy() {
+        PageRequest pageable = PageRequest.of(0, 10);
+        PostComment parent = comment(1L, null);
+        PostComment child1 = comment(2L, 1L);
+        PostComment child2 = comment(3L, 1L);
+
+        given(commentService.findPostWithReplies(anyLong(), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(parent), pageable, 1));
+        given(commentService.findAllByPostId(anyLong()))
+                .willReturn(List.of(parent, child1, child2));
+
+        Page<CommentResponse> result = readCommentService.findComment(10L, 20L, pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        CommentResponse parentRes = result.getContent().get(0);
+        assertThat(parentRes.children()).hasSize(2);
+    }
+
+    private PostComment comment(Long id, Long parentId) {
+        return PostComment.builder()
+                .commentId(id)
+                .postId(20L)
+                .userId(3L)
+                .parentCommentId(parentId)
+                .content("c" + id)
+                .build();
+    }
+}

--- a/src/test/java/com/workhub/post/service/comment/UpdateCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/UpdateCommentServiceTest.java
@@ -1,0 +1,72 @@
+package com.workhub.post.service.comment;
+
+import com.workhub.global.entity.ActionType;
+import com.workhub.global.entity.HistoryType;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
+import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.request.CommentUpdateRequest;
+import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.post.entity.PostComment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateCommentServiceTest {
+
+    @Mock
+    CommentService commentService;
+    @Mock
+    HistoryRecorder historyRecorder;
+
+    @InjectMocks
+    UpdateCommentService updateCommentService;
+
+    @Test
+    @DisplayName("다른 게시글 댓글이면 예외를 던진다")
+    void update_withMismatchedPost_shouldThrow() {
+        PostComment existing = mockComment(1L, 2L, "old");
+        given(commentService.findByCommentAndMatchedUserId(1L, 3L)).willReturn(existing);
+
+        assertThatThrownBy(() -> updateCommentService.update(1L, 99L, 3L, new CommentUpdateRequest("new")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_MATCHED_COMMENT_POST);
+    }
+
+    @Test
+    @DisplayName("정상 수정 시 내용이 변경되고 히스토리가 기록된다")
+    void update_success() {
+        PostComment existing = mockComment(1L, 2L, "old");
+        given(commentService.findByCommentAndMatchedUserId(1L, 3L)).willReturn(existing);
+
+        CommentResponse response = updateCommentService.update(1L, 2L, 3L, new CommentUpdateRequest("new"));
+
+        assertThat(response.commentContent()).isEqualTo("new");
+        verify(historyRecorder).recordHistory(
+                eq(HistoryType.POST),
+                eq(1L),
+                eq(ActionType.UPDATE),
+                eq("old")
+        );
+    }
+
+    private PostComment mockComment(Long commentId, Long postId, String content) {
+        return PostComment.builder()
+                .commentId(commentId)
+                .postId(postId)
+                .userId(3L)
+                .content(content)
+                .build();
+    }
+}

--- a/src/test/java/com/workhub/post/service/comment/UpdateCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/UpdateCommentServiceTest.java
@@ -5,6 +5,7 @@ import com.workhub.global.entity.HistoryType;
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
+import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.dto.comment.request.CommentUpdateRequest;
 import com.workhub.post.dto.comment.response.CommentResponse;
 import com.workhub.post.entity.PostComment;
@@ -17,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -49,15 +49,16 @@ class UpdateCommentServiceTest {
     void update_success() {
         PostComment existing = mockComment(1L, 2L, "old");
         given(commentService.findByCommentAndMatchedUserId(1L, 3L)).willReturn(existing);
+        CommentHistorySnapshot expectedSnapshot = CommentHistorySnapshot.from(existing);
 
         CommentResponse response = updateCommentService.update(1L, 2L, 3L, new CommentUpdateRequest("new"));
 
         assertThat(response.commentContent()).isEqualTo("new");
         verify(historyRecorder).recordHistory(
-                eq(HistoryType.POST),
+                eq(HistoryType.POST_COMMENT),
                 eq(1L),
                 eq(ActionType.UPDATE),
-                eq("old")
+                eq(expectedSnapshot)
         );
     }
 

--- a/src/test/java/com/workhub/post/service/post/CreatePostServiceTest.java
+++ b/src/test/java/com/workhub/post/service/post/CreatePostServiceTest.java
@@ -1,4 +1,4 @@
-package com.workhub.post.service;
+package com.workhub.post.service.post;
 
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
@@ -10,8 +10,6 @@ import com.workhub.post.dto.post.response.PostResponse;
 import com.workhub.post.repository.post.PostFileRepository;
 import com.workhub.post.repository.post.PostLinkRepository;
 import com.workhub.post.repository.post.PostRepository;
-import com.workhub.post.service.post.CreatePostService;
-import com.workhub.post.service.post.PostService;
 import com.workhub.project.entity.Project;
 import com.workhub.project.entity.Status;
 import com.workhub.project.service.ProjectService;

--- a/src/test/java/com/workhub/post/service/post/DeletePostServiceTest.java
+++ b/src/test/java/com/workhub/post/service/post/DeletePostServiceTest.java
@@ -1,4 +1,4 @@
-package com.workhub.post.service;
+package com.workhub.post.service.post;
 
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
@@ -8,8 +8,6 @@ import com.workhub.post.entity.PostType;
 import com.workhub.post.repository.post.PostFileRepository;
 import com.workhub.post.repository.post.PostLinkRepository;
 import com.workhub.post.repository.post.PostRepository;
-import com.workhub.post.service.post.DeletePostService;
-import com.workhub.post.service.post.PostService;
 import com.workhub.project.entity.Project;
 import com.workhub.project.entity.Status;
 import com.workhub.project.service.ProjectService;

--- a/src/test/java/com/workhub/post/service/post/ReadPostServiceTest.java
+++ b/src/test/java/com/workhub/post/service/post/ReadPostServiceTest.java
@@ -1,4 +1,4 @@
-package com.workhub.post.service;
+package com.workhub.post.service.post;
 
 import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostType;
@@ -6,8 +6,6 @@ import com.workhub.post.dto.post.response.PostResponse;
 import com.workhub.post.repository.post.PostFileRepository;
 import com.workhub.post.repository.post.PostLinkRepository;
 import com.workhub.post.repository.post.PostRepository;
-import com.workhub.post.service.post.PostService;
-import com.workhub.post.service.post.ReadPostService;
 import com.workhub.project.entity.Project;
 import com.workhub.project.entity.Status;
 import com.workhub.project.service.ProjectService;

--- a/src/test/java/com/workhub/post/service/post/UpdatePostServiceTest.java
+++ b/src/test/java/com/workhub/post/service/post/UpdatePostServiceTest.java
@@ -1,4 +1,4 @@
-package com.workhub.post.service;
+package com.workhub.post.service.post;
 
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
@@ -10,8 +10,6 @@ import com.workhub.post.dto.post.response.PostResponse;
 import com.workhub.post.repository.post.PostFileRepository;
 import com.workhub.post.repository.post.PostLinkRepository;
 import com.workhub.post.repository.post.PostRepository;
-import com.workhub.post.service.post.PostService;
-import com.workhub.post.service.post.UpdatePostService;
 import com.workhub.project.entity.Project;
 import com.workhub.project.entity.Status;
 import com.workhub.project.service.ProjectService;


### PR DESCRIPTION
 PR 요약

  - [x] 기능 추가
  - [x] 버그 수정
  - [x] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  주요 변경 사항

  - comment_history 분리: 댓글 히스토리를 HistoryType.POST_COMMENT로 분리 저장하도록 스냅샷(CommentHistorySnapshot) 도입 및 Record 호출 수정.
  - HistoryRecorder: 원본 생성자 로그가 없을 때 현재 사용자로 대체해 created_by null 제약 위반을 방지.
  - Comment 서비스/테스트: 스냅샷 기반 히스토리 기록으로 수정하고 전용 히스토리 타입 검증 추가.

  체크리스트

  - [x] 코드가 정상적으로 빌드됩니다.
  - [x] 로컬 테스트를 통과했습니다. 
  - [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
  - [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

  참고 사항

  - 댓글 히스토리는 이제 comment_history에 저장됩니다. 기존에 기록이 없던 댓글의 UPDATE/DELETE 시에는 현재 사용자 ID를 생성자로 대체합니다.

  리뷰어 체크리스트

  - [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
  - [ ] 테스트 커버리지가 충분합니다.
  - [ ] PR 제목과 내용이 일관됩니다.
  - [ ] 커밋 메시지가 명확합니다.