### PR TITLE
refactor: 중복 기능 제거 및 공통 검증로직 분리

### DIFF
--- a/src/main/java/com/workhub/post/controller/CommentController.java
+++ b/src/main/java/com/workhub/post/controller/CommentController.java
@@ -1,24 +1,21 @@
 package com.workhub.post.controller;
 
-import com.workhub.global.error.ErrorCode;
-import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.response.ApiResponse;
+import com.workhub.global.security.CustomUserDetails;
 import com.workhub.post.api.CommentApi;
 import com.workhub.post.dto.comment.request.CommentRequest;
 import com.workhub.post.dto.comment.request.CommentUpdateRequest;
 import com.workhub.post.dto.comment.response.CommentResponse;
-import com.workhub.global.security.CustomUserDetails;
 import com.workhub.post.service.comment.CreateCommentService;
 import com.workhub.post.service.comment.DeleteCommentService;
 import com.workhub.post.service.comment.ReadCommentService;
 import com.workhub.post.service.comment.UpdateCommentService;
-import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -44,7 +41,6 @@ public class CommentController implements CommentApi {
      */
     @Override
     @GetMapping
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse<Page<CommentResponse>>> readComments(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
@@ -66,14 +62,13 @@ public class CommentController implements CommentApi {
      */
     @Override
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<ApiResponse<CommentResponse>> create(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
             @PathVariable Long postId,
             @Valid @RequestBody CommentRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        CommentResponse response = createCommentService.create(projectId, postId, getUserId(userDetails), request);
+        CommentResponse response = createCommentService.create(projectId, postId, userDetails.getUserId(), request);
         return ApiResponse.created(response, "댓글 작성에 성공했습니다.");
     }
 
@@ -90,7 +85,6 @@ public class CommentController implements CommentApi {
      */
     @Override
     @PatchMapping("/{commentId}")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse<CommentResponse>> update(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
@@ -98,7 +92,7 @@ public class CommentController implements CommentApi {
             @PathVariable Long commentId,
             @Valid @RequestBody CommentUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        CommentResponse response = updateCommentService.update(commentId, postId, getUserId(userDetails), request);
+        CommentResponse response = updateCommentService.update(commentId, postId, userDetails.getUserId(), request);
         return ApiResponse.success(response, "댓글 수정에 성공했습니다.");
     }
 
@@ -114,21 +108,13 @@ public class CommentController implements CommentApi {
      */
     @Override
     @DeleteMapping("/{commentId}")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse<Long>> delete(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
             @PathVariable Long postId,
             @PathVariable Long commentId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long result = deleteCommentService.delete(projectId, postId, commentId, getUserId(userDetails));
+        Long result = deleteCommentService.delete(projectId, postId, commentId, userDetails.getUserId());
         return ApiResponse.success(result, "댓글 삭제에 성공했습니다.");
-    }
-
-    private Long getUserId(CustomUserDetails userDetails) {
-        if (userDetails == null) {
-            throw new BusinessException(ErrorCode.NOT_LOGGED_IN);
-        }
-        return userDetails.getUserId();
     }
 }

--- a/src/main/java/com/workhub/post/controller/CommentController.java
+++ b/src/main/java/com/workhub/post/controller/CommentController.java
@@ -92,7 +92,7 @@ public class CommentController implements CommentApi {
             @PathVariable Long commentId,
             @Valid @RequestBody CommentUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        CommentResponse response = updateCommentService.update(commentId, postId, userDetails.getUserId(), request);
+        CommentResponse response = updateCommentService.update(projectId, commentId, postId, userDetails.getUserId(), request);
         return ApiResponse.success(response, "댓글 수정에 성공했습니다.");
     }
 

--- a/src/main/java/com/workhub/post/controller/PostController.java
+++ b/src/main/java/com/workhub/post/controller/PostController.java
@@ -5,22 +5,21 @@ import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.response.ApiResponse;
 import com.workhub.global.security.CustomUserDetails;
 import com.workhub.post.api.PostApi;
-import com.workhub.post.entity.PostType;
 import com.workhub.post.dto.post.request.PostRequest;
 import com.workhub.post.dto.post.request.PostUpdateRequest;
 import com.workhub.post.dto.post.response.PostPageResponse;
 import com.workhub.post.dto.post.response.PostResponse;
+import com.workhub.post.entity.PostType;
 import com.workhub.post.service.post.CreatePostService;
 import com.workhub.post.service.post.DeletePostService;
 import com.workhub.post.service.post.ReadPostService;
 import com.workhub.post.service.post.UpdatePostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,7 +42,6 @@ public class PostController implements PostApi {
      */
     @Override
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<ApiResponse<PostResponse>> createPost(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
@@ -62,7 +60,6 @@ public class PostController implements PostApi {
      */
     @Override
     @GetMapping
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse<PostPageResponse>> getPosts(
             @PathVariable Long projectId,
             @PathVariable Long nodeId,
@@ -94,7 +91,6 @@ public class PostController implements PostApi {
      */
     @Override
     @PatchMapping("/{postId}")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse<PostResponse>> updatePost(@PathVariable Long projectId,
                                                                 @PathVariable Long nodeId,
                                                                 @PathVariable Long postId,
@@ -114,7 +110,6 @@ public class PostController implements PostApi {
      */
     @Override
     @DeleteMapping("/{postId}")
-    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse<Object>> deletePost(@PathVariable Long projectId,
                                                           @PathVariable Long nodeId,
                                                           @PathVariable Long postId,

--- a/src/main/java/com/workhub/post/service/PostValidator.java
+++ b/src/main/java/com/workhub/post/service/PostValidator.java
@@ -1,0 +1,45 @@
+package com.workhub.post.service;
+
+import com.workhub.post.entity.Post;
+import com.workhub.post.service.post.PostService;
+import com.workhub.project.service.ProjectService;
+import com.workhub.projectNode.service.ProjectNodeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 게시글/노드/프로젝트 간 소속 관계를 검증하는 Validator.
+ */
+@Component
+@RequiredArgsConstructor
+public class PostValidator {
+    private final ProjectNodeService projectNodeService;
+    private final ProjectService projectService;
+    private final PostService postService;
+
+    /**
+     * 노드가 프로젝트에 속하고, 프로젝트 상태가 유효한지 검증한다.
+     *
+     * @param nodeId 노드 ID
+     * @param projectId 프로젝트 ID
+     */
+    public void validateNodeAndProject(Long nodeId, Long projectId) {
+        projectNodeService.validateNodeToProject(nodeId, projectId);
+        projectService.validateProject(projectId);
+    }
+
+    /**
+     * 게시글이 프로젝트에 속하는지 검증하고 게시글을 반환한다.
+     * 게시글의 노드 정보를 기반으로 프로젝트 소속을 확인한다.
+     *
+     * @param postId 게시글 ID
+     * @param projectId 프로젝트 ID
+     * @return 검증된 게시글 엔티티
+     */
+    public Post validatePostToProject(Long postId, Long projectId) {
+        Post post = postService.findById(postId);
+        projectNodeService.validateNodeToProject(post.getProjectNodeId(), projectId);
+        return post;
+    }
+}
+

--- a/src/main/java/com/workhub/post/service/comment/CreateCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/CreateCommentService.java
@@ -9,6 +9,7 @@ import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.dto.comment.request.CommentRequest;
 import com.workhub.post.dto.comment.response.CommentResponse;
 import com.workhub.post.entity.PostComment;
+import com.workhub.post.service.PostValidator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class CreateCommentService {
     private final CommentService commentService;
     private final HistoryRecorder historyRecorder;
+    private final PostValidator postValidator;
 
     /**
      * 댓글을 생성하고 히스토리를 기록한다.
@@ -31,6 +33,7 @@ public class CreateCommentService {
      */
     public CommentResponse create(Long projectId, Long postId, Long userId, CommentRequest commentRequest) {
         validateContent(commentRequest.content());
+        postValidator.validatePostToProject(postId, projectId);
 
         Long parentCommentId = resolveParent(postId, commentRequest.parentCommentId());
         PostComment postComment = PostComment.of(postId, userId, parentCommentId, commentRequest.content());

--- a/src/main/java/com/workhub/post/service/comment/DeleteCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/DeleteCommentService.java
@@ -7,6 +7,7 @@ import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
 import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.entity.PostComment;
+import com.workhub.post.service.PostValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ import java.util.List;
 public class DeleteCommentService {
     private final CommentService commentService;
     private final HistoryRecorder historyRecorder;
+    private final PostValidator postValidator;
 
     /**
      * 댓글과 자식 댓글을 삭제(소프트 딜리트)하고 히스토리를 기록한다.
@@ -30,6 +32,7 @@ public class DeleteCommentService {
      * @return 삭제된 댓글의 게시글 ID
      */
     public Long delete(Long projectId, Long postId, Long commentId, Long userId) {
+        postValidator.validatePostToProject(postId, projectId);
         PostComment postComment = commentService.findByCommentAndMatchedUserId(commentId, userId);
 
         if (!postId.equals(postComment.getPostId())) {

--- a/src/main/java/com/workhub/post/service/comment/ReadCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/ReadCommentService.java
@@ -2,6 +2,7 @@ package com.workhub.post.service.comment;
 
 import com.workhub.post.dto.comment.response.CommentResponse;
 import com.workhub.post.entity.PostComment;
+import com.workhub.post.service.PostValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -19,8 +20,11 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ReadCommentService {
     private final CommentService commentService;
+    private final PostValidator postValidator;
 
     public Page<CommentResponse> findComment(Long projectId, Long postId, Pageable pageable) {
+        postValidator.validatePostToProject(postId, projectId);
+
         List<PostComment> allComments = commentService.findAllByPostId(postId);
 
         Page<PostComment> topLevelComments = commentService.findPostWithReplies(postId, pageable);

--- a/src/main/java/com/workhub/post/service/comment/UpdateCommentService.java
+++ b/src/main/java/com/workhub/post/service/comment/UpdateCommentService.java
@@ -9,6 +9,7 @@ import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.dto.comment.request.CommentUpdateRequest;
 import com.workhub.post.dto.comment.response.CommentResponse;
 import com.workhub.post.entity.PostComment;
+import com.workhub.post.service.PostValidator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,17 +20,20 @@ import org.springframework.stereotype.Service;
 public class UpdateCommentService {
     private final CommentService commentService;
     private final HistoryRecorder historyRecorder;
+    private final PostValidator postValidator;
 
     /**
      * 댓글을 수정하고 변경 전 내용을 히스토리에 저장한다.
      *
      * @param postCommentId 댓글 식별자
+     * @param projectId 프로젝트 식별자
      * @param postId 게시글 식별자
      * @param userId 작성자 식별자
      * @param commentUpdateRequest 수정 요청 본문
      * @return 수정된 댓글 응답
      */
-    public CommentResponse update(Long postCommentId, Long postId, Long userId, CommentUpdateRequest commentUpdateRequest) {
+    public CommentResponse update(Long projectId, Long postCommentId, Long postId, Long userId, CommentUpdateRequest commentUpdateRequest) {
+        postValidator.validatePostToProject(postId, projectId);
         PostComment postComment = commentService.findByCommentAndMatchedUserId(postCommentId, userId);
 
         validateCommentBelongs(postComment, postId);

--- a/src/main/java/com/workhub/post/service/post/CreatePostService.java
+++ b/src/main/java/com/workhub/post/service/post/CreatePostService.java
@@ -1,19 +1,19 @@
 package com.workhub.post.service.post;
 
-import com.workhub.global.error.ErrorCode;
-import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.entity.ActionType;
 import com.workhub.global.entity.HistoryType;
+import com.workhub.global.error.ErrorCode;
+import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
-import com.workhub.post.entity.Post;
-import com.workhub.post.entity.PostFile;
-import com.workhub.post.entity.PostLink;
 import com.workhub.post.dto.post.PostHistorySnapshot;
 import com.workhub.post.dto.post.request.PostFileRequest;
 import com.workhub.post.dto.post.request.PostLinkRequest;
 import com.workhub.post.dto.post.request.PostRequest;
 import com.workhub.post.dto.post.response.PostResponse;
-import com.workhub.project.service.ProjectService;
+import com.workhub.post.entity.Post;
+import com.workhub.post.entity.PostFile;
+import com.workhub.post.entity.PostLink;
+import com.workhub.post.service.PostValidator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +26,7 @@ import java.util.List;
 public class CreatePostService {
 
     private final PostService postService;
-    private final ProjectService projectService;
+    private final PostValidator postValidator;
     private final HistoryRecorder historyRecorder;
 
     /**
@@ -39,7 +39,7 @@ public class CreatePostService {
      * @return 저장된 게시글
      */
     public PostResponse create(Long projectId, Long projectNodeId, Long userId, PostRequest request) {
-        projectService.validateProject(projectId);
+        postValidator.validateNodeAndProject(projectNodeId, projectId);
 
         Long parentPostId = request.parentPostId();
         if (parentPostId != null && !postService.existsActivePost(parentPostId)) {

--- a/src/main/java/com/workhub/post/service/post/DeletePostService.java
+++ b/src/main/java/com/workhub/post/service/post/DeletePostService.java
@@ -9,7 +9,7 @@ import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostFile;
 import com.workhub.post.dto.post.PostHistorySnapshot;
 import com.workhub.post.entity.PostLink;
-import com.workhub.project.service.ProjectService;
+import com.workhub.post.service.PostValidator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,8 +20,9 @@ import org.springframework.stereotype.Service;
 public class DeletePostService {
 
     private final PostService postService;
-    private final ProjectService projectService;
+    private final PostValidator postValidator;
     private final HistoryRecorder historyRecorder;
+
 
     /**
      * 게시글 삭제 시 프로젝트/노드 검증과 작성자 권한을 체크한다.
@@ -31,7 +32,7 @@ public class DeletePostService {
      * @param postId 게시글 ID
      */
     public void delete(Long projectId, Long nodeId, Long postId, Long userId) {
-        projectService.validateProject(projectId);
+        postValidator.validateNodeAndProject(nodeId, projectId);
         Post target = postService.findById(postId);
         postService.validateNode(target, nodeId);
         if (target.isDeleted()) {

--- a/src/main/java/com/workhub/post/service/post/ReadPostService.java
+++ b/src/main/java/com/workhub/post/service/post/ReadPostService.java
@@ -7,7 +7,7 @@ import com.workhub.post.entity.PostType;
 import com.workhub.post.dto.post.response.PostPageResponse;
 import com.workhub.post.dto.post.response.PostResponse;
 import com.workhub.post.dto.post.response.PostThreadResponse;
-import com.workhub.project.service.ProjectService;
+import com.workhub.post.service.PostValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,8 +24,7 @@ import java.util.Map;
 public class ReadPostService {
 
     private final PostService postService;
-    private final ProjectService projectService;
-
+    private final PostValidator postValidator;
     /**
      * 프로젝트/노드 범위 내 게시글을 단건 조회한다.
      *
@@ -35,7 +34,7 @@ public class ReadPostService {
      * @return 조회된 게시글
      */
     public PostResponse findById(Long projectId, Long nodeId, Long postId) {
-        projectService.validateProject(projectId);
+        postValidator.validateNodeAndProject(nodeId, projectId);
         Post post = postService.findById(postId);
         postService.validateNode(post, nodeId);
 
@@ -65,7 +64,7 @@ public class ReadPostService {
                                    String keyword,
                                    PostType postType,
                                    Pageable pageable) {
-        projectService.validateProject(projectId);
+        postValidator.validateNodeAndProject(nodeId, projectId);
 
         Page<Post> parentPage = postService.searchParentPosts(nodeId, keyword, postType, pageable);
 

--- a/src/main/java/com/workhub/post/service/post/UpdatePostService.java
+++ b/src/main/java/com/workhub/post/service/post/UpdatePostService.java
@@ -13,7 +13,7 @@ import com.workhub.post.dto.post.request.PostFileUpdateRequest;
 import com.workhub.post.dto.post.request.PostLinkUpdateRequest;
 import com.workhub.post.dto.post.request.PostUpdateRequest;
 import com.workhub.post.dto.post.response.PostResponse;
-import com.workhub.project.service.ProjectService;
+import com.workhub.post.service.PostValidator;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,14 +27,16 @@ import java.util.stream.Collectors;
 public class UpdatePostService {
 
     private final PostService postService;
-    private final ProjectService projectService;
+    private final PostValidator postValidator;
     private final HistoryRecorder historyRecorder;
+
 
     /**
      * 프로젝트와 노드 일치 여부, 작성자 권한을 검증한 뒤 게시글을 수정한다.
      */
     public PostResponse update(Long projectId, Long nodeId, Long postId, Long userId, PostUpdateRequest request) {
-        projectService.validateProject(projectId);
+        postValidator.validateNodeAndProject(nodeId, projectId);
+
         Post target = postService.findById(postId);
         postService.validateNode(target, nodeId);
         if (!target.getUserId().equals(userId)) {

--- a/src/main/java/com/workhub/projectNode/service/ProjectNodeService.java
+++ b/src/main/java/com/workhub/projectNode/service/ProjectNodeService.java
@@ -17,7 +17,6 @@ import java.util.Map;
 public class ProjectNodeService {
 
     private final ProjectNodeRepository projectNodeRepository;
-    private final ProjectNodeService projectNodeService;
 
     public ProjectNode saveProjectNode(ProjectNode projectNode){
         return projectNodeRepository.save(projectNode);
@@ -42,8 +41,8 @@ public class ProjectNodeService {
     }
 
     public void validateNodeToProject(Long nodeId, Long projectId){
-        ProjectNode node = projectNodeService.findById(nodeId);
-        if (!node.getProjectNodeId().equals(projectId)) {
+        ProjectNode node = findById(nodeId);
+        if (!node.getProjectId().equals(projectId)) {
             throw new BusinessException(ErrorCode.NOT_MATCHED_PROJECT_POST);
         }
     }

--- a/src/main/java/com/workhub/projectNode/service/ProjectNodeService.java
+++ b/src/main/java/com/workhub/projectNode/service/ProjectNodeService.java
@@ -17,6 +17,7 @@ import java.util.Map;
 public class ProjectNodeService {
 
     private final ProjectNodeRepository projectNodeRepository;
+    private final ProjectNodeService projectNodeService;
 
     public ProjectNode saveProjectNode(ProjectNode projectNode){
         return projectNodeRepository.save(projectNode);
@@ -38,5 +39,12 @@ public class ProjectNodeService {
 
     public Map<Long, Long> getProjectNodeCountMapByProjectIdIn(List<Long> projectIds) {
         return projectNodeRepository.countMapByProjectIdIn(projectIds);
+    }
+
+    public void validateNodeToProject(Long nodeId, Long projectId){
+        ProjectNode node = projectNodeService.findById(nodeId);
+        if (!node.getProjectNodeId().equals(projectId)) {
+            throw new BusinessException(ErrorCode.NOT_MATCHED_PROJECT_POST);
+        }
     }
 }

--- a/src/test/java/com/workhub/post/service/comment/CreateCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/CreateCommentServiceTest.java
@@ -8,31 +8,47 @@ import com.workhub.global.history.HistoryRecorder;
 import com.workhub.post.dto.comment.CommentHistorySnapshot;
 import com.workhub.post.dto.comment.request.CommentRequest;
 import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostComment;
+import com.workhub.post.service.PostValidator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CreateCommentServiceTest {
 
     @Mock
     CommentService commentService;
     @Mock
     HistoryRecorder historyRecorder;
+    @Mock
+    PostValidator postValidator;
 
     @InjectMocks
     CreateCommentService createCommentService;
+
+    @BeforeEach
+    void setUp() {
+        given(postValidator.validatePostToProject(anyLong(), anyLong()))
+                .willReturn(Post.builder().build());
+    }
 
     @Test
     @DisplayName("내용이 비어 있으면 예외를 던진다")

--- a/src/test/java/com/workhub/post/service/comment/DeleteCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/DeleteCommentServiceTest.java
@@ -6,15 +6,21 @@ import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.global.history.HistoryRecorder;
 import com.workhub.post.dto.comment.CommentHistorySnapshot;
+import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostComment;
+import com.workhub.post.service.PostValidator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Collections;
+import static org.mockito.BDDMockito.willDoNothing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -24,15 +30,25 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class DeleteCommentServiceTest {
 
     @Mock
     CommentService commentService;
     @Mock
     HistoryRecorder historyRecorder;
+    @Mock
+    PostValidator postValidator;
 
     @InjectMocks
     DeleteCommentService deleteCommentService;
+
+    @BeforeEach
+    void setUp() {
+        deleteCommentService = new DeleteCommentService(commentService, historyRecorder, postValidator);
+        given(postValidator.validatePostToProject(anyLong(), anyLong()))
+                .willReturn(Post.builder().build());
+    }
 
     @Test
     @DisplayName("다른 게시글 댓글이면 삭제 시 예외를 던진다")

--- a/src/test/java/com/workhub/post/service/comment/ReadCommentServiceTest.java
+++ b/src/test/java/com/workhub/post/service/comment/ReadCommentServiceTest.java
@@ -1,7 +1,10 @@
 package com.workhub.post.service.comment;
 
 import com.workhub.post.dto.comment.response.CommentResponse;
+import com.workhub.post.entity.Post;
 import com.workhub.post.entity.PostComment;
+import com.workhub.post.service.PostValidator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,9 +28,18 @@ class ReadCommentServiceTest {
 
     @Mock
     CommentService commentService;
+    @Mock
+    PostValidator postValidator;
 
     @InjectMocks
     ReadCommentService readCommentService;
+
+    @BeforeEach
+    void setUp() {
+        readCommentService = new ReadCommentService(commentService, postValidator);
+        given(postValidator.validatePostToProject(anyLong(), anyLong()))
+                .willReturn(Post.builder().build());
+    }
 
     @Test
     @DisplayName("최상위 댓글과 자식 댓글을 계층 구조로 반환한다")


### PR DESCRIPTION
 PR 요약

  - [x] 기능 추가
  - [x] 버그 수정
  - [ ] 코드 리팩토링
  - [ ] 문서 수정
  - [ ] 기타 (설명)

  주요 변경 사항

  - post/service/PostValidator.java: 프로젝트-노드-게시글 소속 검증 공통 컴포넌트 추가.
  - Create/Read/Update/DeletePostService: Validator 기반으로 프로젝트/노드 검증 통합.
  - Create/Read/Update/DeleteCommentService, ReadCommentService: 댓글 처리 시 게시글-프로젝트 소속 검증 추가.
  - 테스트 전반(post/service/post/*Test, post/service/comment/*Test): PostValidator 주입/스텁에 맞춰 수정 및 통과 확인.

  체크리스트

  - [x] 코드가 정상적으로 빌드됩니다.
  - [x] 로컬 테스트를 통과했습니다. 
  - [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
  - [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

  참고 사항

  - 경로 파라미터 체인(project → node → post → comment)을 Validator로 검증하도록 적용했습니다.
  - 새 Validator 경로는 com.workhub.post.service.PostValidator입니다.

  리뷰어 체크리스트

  - [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
  - [ ] 테스트 커버리지가 충분합니다.
  - [ ] PR 제목과 내용이 일관됩니다.
  - [ ] 커밋 메시지가 명확합니다.