### PR TITLE
fix : 프로젝트 수정 시 구성원 변경이 안 되는 문제를 해결(#4)

### DIFF
--- a/src/main/java/com/workhub/project/dto/request/CreateProjectRequest.java
+++ b/src/main/java/com/workhub/project/dto/request/CreateProjectRequest.java
@@ -15,9 +15,9 @@ public record CreateProjectRequest(
         @NotEmpty
         Long company,
         @NotEmpty
-        List<Long> managerNames,
+        List<Long> managerIds,
         @NotEmpty
-        List<Long> developerNames,
+        List<Long> developerIds,
         @NotEmpty
         LocalDate starDate,
         @NotEmpty

--- a/src/main/java/com/workhub/project/entity/ProjectClientMember.java
+++ b/src/main/java/com/workhub/project/entity/ProjectClientMember.java
@@ -36,6 +36,10 @@ public class ProjectClientMember {
     @Column(name = "project_id")
     private Long projectId;
 
+    public void removeMember() {
+        this.removedAt = LocalDate.now();
+    }
+
     public static ProjectClientMember of(Long userId, Long projectId) {
         return ProjectClientMember.builder()
                 .assignedAt(LocalDate.now())

--- a/src/main/java/com/workhub/project/entity/ProjectDevMember.java
+++ b/src/main/java/com/workhub/project/entity/ProjectDevMember.java
@@ -36,6 +36,10 @@ public class ProjectDevMember {
     @Column(name = "project_id")
     private Long projectId;
 
+    public void removeMember() {
+        this.removedAt = LocalDate.now();
+    }
+
     public static ProjectDevMember of(Long userId, Long projectId) {
         return ProjectDevMember.builder()
                 .assignedAt(LocalDate.now())

--- a/src/main/java/com/workhub/project/service/UpdateProjectService.java
+++ b/src/main/java/com/workhub/project/service/UpdateProjectService.java
@@ -8,10 +8,14 @@ import com.workhub.project.dto.ProjectHistorySnapshot;
 import com.workhub.project.dto.response.ProjectResponse;
 import com.workhub.project.dto.request.UpdateStatusRequest;
 import com.workhub.project.entity.Project;
+import com.workhub.project.entity.ProjectClientMember;
+import com.workhub.project.entity.ProjectDevMember;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -49,13 +53,194 @@ public class UpdateProjectService {
      */
     public ProjectResponse updateProject(Long projectId, CreateProjectRequest request) {
 
+        // 1. 프로젝트 업데이트
+        Project updatedProject = updateProjectAndHistory(projectId, request);
+
+        // 2. 기존 멤버 조회
+        List<ProjectClientMember> existingClientMembers = projectService.getClientMemberByProjectId(projectId);
+        List<ProjectDevMember> existingDevMembers = projectService.getDevMemberByProjectId(projectId);
+
+        // 3. 변경사항 결정
+        List<Long> toRemoveClientIds = determineClientMembersToRemove(existingClientMembers, request.managerIds());
+        List<Long> toAddClientIds = determineClientMembersToAdd(existingClientMembers, request.managerIds());
+        List<Long> toRemoveDevIds = determineDevMembersToRemove(existingDevMembers, request.developerIds());
+        List<Long> toAddDevIds = determineDevMembersToAdd(existingDevMembers, request.developerIds());
+
+        // 4. 멤버 업데이트
+        removeClientMembersAndHistory(existingClientMembers, toRemoveClientIds, projectId);
+        removeDevMembersAndHistory(existingDevMembers, toRemoveDevIds, projectId);
+        saveClientMembersAndHistory(toAddClientIds, projectId);
+        saveDevMembersAndHistory(toAddDevIds, projectId);
+
+        return ProjectResponse.from(updatedProject);
+    }
+
+    /**
+     * 프로젝트에 배정된 고객사 멤버를 저장하고, 히스토리를 함께 저장
+     * @param clientIds 고객사 멤버 PK
+     * @param projectId 프로젝트 PK
+     */
+    private void saveClientMembersAndHistory(List<Long> clientIds, Long projectId) {
+
+        List<ProjectClientMember> savedClientMembers = projectService.saveClientMembers(clientIds, projectId);
+
+        savedClientMembers.forEach(member ->
+                historyRecorder.recordHistory(
+                        HistoryType.PROJECT_CLIENT_MEMBER,
+                        member.getProjectClientMemberId(),
+                        ActionType.CREATE,
+                        member
+                )
+        );
+    }
+
+    /**
+     * 프로젝트에 배정된 개발자 멤버를 저장하고, 히스토리를 함께 저장
+     * @param devIds 개발자 멤버 PK
+     * @param projectId 프로젝트 PK
+     */
+    private void saveDevMembersAndHistory(List<Long> devIds, Long projectId) {
+
+        List<ProjectDevMember> savedDevMembers = projectService.saveDevMembers(devIds, projectId);
+
+        savedDevMembers.forEach(member ->
+                historyRecorder.recordHistory(
+                        HistoryType.PROJECT_DEV_MEMBER,
+                        member.getProjectMemberId(),
+                        ActionType.CREATE,
+                        member
+                )
+        );
+    }
+
+    /**
+     * 프로젝트를 업데이트하고 히스토리를 기록
+     * @param projectId 프로젝트 ID
+     * @param request 업데이트 요청
+     * @return 업데이트된 프로젝트
+     */
+    private Project updateProjectAndHistory(Long projectId, CreateProjectRequest request) {
         Project original = projectService.findProjectById(projectId);
         ProjectHistorySnapshot snapshot = ProjectHistorySnapshot.from(original);
 
         original.update(request);
         historyRecorder.recordHistory(HistoryType.PROJECT, projectId, ActionType.UPDATE, snapshot);
 
-        return ProjectResponse.from(original);
+        return original;
+    }
+
+    /**
+     * 클라이언트 멤버를 삭제하고 히스토리를 기록
+     * @param existingMembers 기존 클라이언트 멤버 리스트
+     * @param toRemoveIds 삭제할 멤버 ID 리스트
+     * @param projectId 프로젝트 ID
+     */
+    private void removeClientMembersAndHistory(
+            List<ProjectClientMember> existingMembers,
+            List<Long> toRemoveIds,
+            Long projectId
+    ) {
+        toRemoveIds.forEach(userId -> {
+            ProjectClientMember member = existingMembers.stream()
+                    .filter(m -> m.getUserId().equals(userId))
+                    .findFirst()
+                    .orElseThrow();
+            member.removeMember();
+            historyRecorder.recordHistory(HistoryType.PROJECT_CLIENT_MEMBER, projectId, ActionType.DELETE, member);
+        });
+    }
+
+    /**
+     * 개발자 멤버를 삭제하고 히스토리를 기록
+     * @param existingMembers 기존 개발자 멤버 리스트
+     * @param toRemoveIds 삭제할 멤버 ID 리스트
+     * @param projectId 프로젝트 ID
+     */
+    private void removeDevMembersAndHistory(
+            List<ProjectDevMember> existingMembers,
+            List<Long> toRemoveIds,
+            Long projectId
+    ) {
+        toRemoveIds.forEach(userId -> {
+            ProjectDevMember member = existingMembers.stream()
+                    .filter(m -> m.getUserId().equals(userId))
+                    .findFirst()
+                    .orElseThrow();
+            member.removeMember();
+            historyRecorder.recordHistory(HistoryType.PROJECT_DEV_MEMBER, projectId, ActionType.DELETE, member);
+        });
+    }
+
+    /**
+     * 삭제할 클라이언트 멤버 ID 결정
+     * @param existingMembers 기존 클라이언트 멤버
+     * @param requestedIds 요청된 클라이언트 멤버 ID
+     * @return 삭제할 멤버 ID 리스트
+     */
+    private List<Long> determineClientMembersToRemove(
+            List<ProjectClientMember> existingMembers,
+            List<Long> requestedIds
+    ) {
+        List<Long> existingIds = existingMembers.stream()
+                .map(ProjectClientMember::getUserId)
+                .toList();
+        return existingIds.stream()
+                .filter(id -> !requestedIds.contains(id))
+                .toList();
+    }
+
+    /**
+     * 추가할 클라이언트 멤버 ID 결정
+     * @param existingMembers 기존 클라이언트 멤버
+     * @param requestedIds 요청된 클라이언트 멤버 ID
+     * @return 추가할 멤버 ID 리스트
+     */
+    private List<Long> determineClientMembersToAdd(
+            List<ProjectClientMember> existingMembers,
+            List<Long> requestedIds
+    ) {
+        List<Long> existingIds = existingMembers.stream()
+                .map(ProjectClientMember::getUserId)
+                .toList();
+        return requestedIds.stream()
+                .filter(id -> !existingIds.contains(id))
+                .toList();
+    }
+
+    /**
+     * 삭제할 개발자 멤버 ID 결정
+     * @param existingMembers 기존 개발자 멤버
+     * @param requestedIds 요청된 개발자 멤버 ID
+     * @return 삭제할 멤버 ID 리스트
+     */
+    private List<Long> determineDevMembersToRemove(
+            List<ProjectDevMember> existingMembers,
+            List<Long> requestedIds
+    ) {
+        List<Long> existingIds = existingMembers.stream()
+                .map(ProjectDevMember::getUserId)
+                .toList();
+        return existingIds.stream()
+                .filter(id -> !requestedIds.contains(id))
+                .toList();
+    }
+
+    /**
+     * 추가할 개발자 멤버 ID 결정
+     * @param existingMembers 기존 개발자 멤버
+     * @param requestedIds 요청된 개발자 멤버 ID
+     * @return 추가할 멤버 ID 리스트
+     */
+    private List<Long> determineDevMembersToAdd(
+            List<ProjectDevMember> existingMembers,
+            List<Long> requestedIds
+    ) {
+        List<Long> existingIds = existingMembers.stream()
+                .map(ProjectDevMember::getUserId)
+                .toList();
+        return requestedIds.stream()
+                .filter(id -> !existingIds.contains(id))
+                .toList();
     }
 
 }

--- a/src/test/java/com/workhub/project/service/CreateProjectServiceTest.java
+++ b/src/test/java/com/workhub/project/service/CreateProjectServiceTest.java
@@ -3,12 +3,15 @@ package com.workhub.project.service;
 import com.workhub.global.entity.ActionType;
 import com.workhub.global.entity.HistoryType;
 import com.workhub.global.history.HistoryRecorder;
-import com.workhub.global.security.CustomUserDetails;
-import com.workhub.project.dto.request.CreateProjectRequest;
 import com.workhub.project.dto.ProjectHistorySnapshot;
+import com.workhub.project.dto.request.CreateProjectRequest;
 import com.workhub.project.dto.response.ProjectResponse;
-import com.workhub.project.entity.*;
-import com.workhub.userTable.entity.UserTable;
+import com.workhub.project.entity.DevPart;
+import com.workhub.project.entity.Project;
+import com.workhub.project.entity.ProjectClientMember;
+import com.workhub.project.entity.ProjectDevMember;
+import com.workhub.project.entity.Role;
+import com.workhub.project.entity.Status;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,20 +19,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
-import static com.workhub.userTable.entity.UserRole.ADMIN;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class CreateProjectServiceTest {
@@ -43,298 +40,195 @@ class CreateProjectServiceTest {
     @InjectMocks
     private CreateProjectService createProjectService;
 
-    private CreateProjectRequest mockRequest;
+    private CreateProjectRequest request;
     private Project mockProject;
-    private ProjectClientMember mockClientMember;
-    private ProjectDevMember mockDevMember;
+    private List<ProjectClientMember> mockClientMembers;
+    private List<ProjectDevMember> mockDevMembers;
 
     @BeforeEach
     void init() {
-        // SecurityContext 설정
-        UserTable mockUser = UserTable.builder()
-                .userId(1L)
-                .loginId("testuser")
-                .password("password")
-                .role(ADMIN)
-                .build();
-
-        CustomUserDetails userDetails = new CustomUserDetails(mockUser);
-        UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        mockRequest = new CreateProjectRequest(
-                "테스트 프로젝트",
-                "프로젝트 설명입니다",
+        request = new CreateProjectRequest(
+                "신규 프로젝트",
+                "프로젝트 설명",
                 100L,
-                Arrays.asList(1L, 2L),
-                Arrays.asList(3L, 4L),
-                LocalDate.of(2025, 1, 1),
-                LocalDate.of(2025, 6, 30)
+                Arrays.asList(1L, 2L),  // managerIds
+                Arrays.asList(10L, 20L),  // developerIds
+                LocalDate.now(),
+                LocalDate.now().plusMonths(6)
         );
 
         mockProject = Project.builder()
                 .projectId(1L)
-                .projectTitle("테스트 프로젝트")
-                .projectDescription("프로젝트 설명입니다")
-                .status(Status.CONTRACT)
-                .contractStartDate(LocalDate.of(2025, 1, 1))
-                .contractEndDate(LocalDate.of(2025, 6, 30))
+                .projectTitle("신규 프로젝트")
+                .projectDescription("프로젝트 설명")
+                .status(Status.IN_PROGRESS)
+                .contractStartDate(LocalDate.now())
+                .contractEndDate(LocalDate.now().plusMonths(6))
                 .clientCompanyId(100L)
                 .build();
 
-        mockClientMember = ProjectClientMember.builder()
-                .projectClientMemberId(1L)
-                .userId(1L)
-                .projectId(1L)
-                .role(Role.READ)
-                .assignedAt(LocalDate.now())
-                .build();
-
-        mockDevMember = ProjectDevMember.builder()
-                .projectMemberId(1L)
-                .userId(3L)
-                .projectId(1L)
-                .devPart(DevPart.BE)
-                .assignedAt(LocalDate.now())
-                .build();
-    }
-
-    @Test
-    @DisplayName("프로젝트 생성 요청 시 프로젝트가 생성되고 응답이 반환된다.")
-    void givenCreateProjectRequest_whenCreateProject_thenReturnProjectResponse() {
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        when(projectService.saveProjectClientMember(anyList())).thenReturn(Arrays.asList(mockClientMember));
-        when(projectService.saveProjectDevMember(anyList())).thenReturn(Arrays.asList(mockDevMember));
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-
-        ProjectResponse result = createProjectService.createProject(mockRequest);
-
-        assertThat(result).isNotNull();
-        assertThat(result.projectId()).isEqualTo(1L);
-        assertThat(result.projectTitle()).isEqualTo("테스트 프로젝트");
-        assertThat(result.projectDescription()).isEqualTo("프로젝트 설명입니다");
-        assertThat(result.status()).isEqualTo(Status.CONTRACT);
-        assertThat(result.contractStartDate()).isEqualTo(LocalDate.of(2025, 1, 1));
-        assertThat(result.contractEndDate()).isEqualTo(LocalDate.of(2025, 6, 30));
-
-        verify(projectService).saveProject(any(Project.class));
-        verify(historyRecorder).recordHistory(eq(HistoryType.PROJECT), eq(1L), eq(ActionType.CREATE), any(ProjectHistorySnapshot.class));
-    }
-
-    @Test
-    @DisplayName("프로젝트 생성 시 클라이언트 멤버가 저장되고 히스토리가 기록된다.")
-    void givenCreateProjectRequest_whenCreateProject_thenSaveClientMembersAndHistory() {
-        ProjectClientMember clientMember1 = ProjectClientMember.builder()
-                .projectClientMemberId(1L)
-                .userId(1L)
-                .projectId(1L)
-                .build();
-
-        ProjectClientMember clientMember2 = ProjectClientMember.builder()
-                .projectClientMemberId(2L)
-                .userId(2L)
-                .projectId(1L)
-                .build();
-
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        when(projectService.saveProjectClientMember(anyList())).thenReturn(Arrays.asList(clientMember1, clientMember2));
-        when(projectService.saveProjectDevMember(anyList())).thenReturn(Arrays.asList(mockDevMember));
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-
-        createProjectService.createProject(mockRequest);
-
-        verify(projectService).saveProjectClientMember(argThat(list ->
-                list.size() == 2 &&
-                list.stream().anyMatch(m -> m.getUserId().equals(1L)) &&
-                list.stream().anyMatch(m -> m.getUserId().equals(2L))
-        ));
-        verify(historyRecorder, times(2)).recordHistory(eq(HistoryType.PROJECT_CLIENT_MEMBER), anyLong(), eq(ActionType.CREATE), any(ProjectClientMember.class));
-    }
-
-    @Test
-    @DisplayName("프로젝트 생성 시 개발 멤버가 저장되고 히스토리가 기록된다.")
-    void givenCreateProjectRequest_whenCreateProject_thenSaveDevMembersAndHistory() {
-        ProjectDevMember devMember1 = ProjectDevMember.builder()
-                .projectMemberId(1L)
-                .userId(3L)
-                .projectId(1L)
-                .build();
-
-        ProjectDevMember devMember2 = ProjectDevMember.builder()
-                .projectMemberId(2L)
-                .userId(4L)
-                .projectId(1L)
-                .build();
-
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        when(projectService.saveProjectClientMember(anyList())).thenReturn(Arrays.asList(mockClientMember));
-        when(projectService.saveProjectDevMember(anyList())).thenReturn(Arrays.asList(devMember1, devMember2));
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-
-        createProjectService.createProject(mockRequest);
-
-        verify(projectService).saveProjectDevMember(argThat(list ->
-                list.size() == 2 &&
-                list.stream().anyMatch(m -> m.getUserId().equals(3L)) &&
-                list.stream().anyMatch(m -> m.getUserId().equals(4L))
-        ));
-        verify(historyRecorder, times(2)).recordHistory(eq(HistoryType.PROJECT_DEV_MEMBER), anyLong(), eq(ActionType.CREATE), any(ProjectDevMember.class));
-    }
-
-    @Test
-    @DisplayName("프로젝트 생성 시 요청 데이터가 엔티티로 올바르게 매핑된다.")
-    void givenCreateProjectRequest_whenCreateProject_thenRequestMappedToEntity() {
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        when(projectService.saveProjectClientMember(anyList())).thenReturn(Arrays.asList(mockClientMember));
-        when(projectService.saveProjectDevMember(anyList())).thenReturn(Arrays.asList(mockDevMember));
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-
-        createProjectService.createProject(mockRequest);
-
-        verify(projectService).saveProject(argThat(project ->
-                project.getProjectTitle().equals("테스트 프로젝트") &&
-                project.getProjectDescription().equals("프로젝트 설명입니다") &&
-                project.getStatus().equals(Status.CONTRACT) &&
-                project.getClientCompanyId().equals(100L)
-        ));
-    }
-
-    @Test
-    @DisplayName("프로젝트 저장 실패 시 예외가 발생한다.")
-    void givenCreateProjectRequest_whenSaveProjectFails_thenThrowException() {
-        when(projectService.saveProject(any(Project.class)))
-                .thenThrow(new RuntimeException("프로젝트 저장 실패"));
-
-        assertThatThrownBy(() -> createProjectService.createProject(mockRequest))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("프로젝트 저장 실패");
-
-        verify(projectService).saveProject(any(Project.class));
-        verify(historyRecorder, never()).recordHistory(any(), anyLong(), any(), any());
-        verify(projectService, never()).saveProjectClientMember(anyList());
-        verify(projectService, never()).saveProjectDevMember(anyList());
-    }
-
-    @Test
-    @DisplayName("히스토리 기록 실패 시 예외가 전파된다.")
-    void givenCreateProjectRequest_whenHistoryRecordFails_thenThrowException() {
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        lenient().doThrow(new RuntimeException("히스토리 저장 실패"))
-                .when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-
-        assertThatThrownBy(() -> createProjectService.createProject(mockRequest))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("히스토리 저장 실패");
-
-        verify(projectService).saveProject(any(Project.class));
-        verify(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-        verify(projectService, never()).saveProjectClientMember(anyList());
-    }
-
-    @Test
-    @DisplayName("클라이언트 멤버 저장 실패 시 예외가 전파된다.")
-    void givenCreateProjectRequest_whenSaveClientMemberFails_thenThrowException() {
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-        when(projectService.saveProjectClientMember(anyList()))
-                .thenThrow(new RuntimeException("클라이언트 멤버 저장 실패"));
-
-        assertThatThrownBy(() -> createProjectService.createProject(mockRequest))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("클라이언트 멤버 저장 실패");
-
-        verify(projectService).saveProject(any(Project.class));
-        verify(historyRecorder).recordHistory(eq(HistoryType.PROJECT), anyLong(), eq(ActionType.CREATE), any(ProjectHistorySnapshot.class));
-        verify(projectService).saveProjectClientMember(anyList());
-        verify(historyRecorder, never()).recordHistory(eq(HistoryType.PROJECT_CLIENT_MEMBER), anyLong(), eq(ActionType.CREATE), any());
-    }
-
-    @Test
-    @DisplayName("개발 멤버 저장 실패 시 예외가 전파된다.")
-    void givenCreateProjectRequest_whenSaveDevMemberFails_thenThrowException() {
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-        when(projectService.saveProjectClientMember(anyList())).thenReturn(Arrays.asList(mockClientMember));
-        when(projectService.saveProjectDevMember(anyList()))
-                .thenThrow(new RuntimeException("개발 멤버 저장 실패"));
-
-        assertThatThrownBy(() -> createProjectService.createProject(mockRequest))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("개발 멤버 저장 실패");
-
-        verify(projectService).saveProject(any(Project.class));
-        verify(projectService).saveProjectClientMember(anyList());
-        verify(projectService).saveProjectDevMember(anyList());
-        verify(historyRecorder, never()).recordHistory(eq(HistoryType.PROJECT_DEV_MEMBER), anyLong(), eq(ActionType.CREATE), any());
-    }
-
-    @Test
-    @DisplayName("빈 클라이언트 멤버 리스트로 프로젝트 생성 시 빈 리스트가 저장된다.")
-    void givenEmptyClientMemberList_whenCreateProject_thenSaveEmptyList() {
-        CreateProjectRequest requestWithEmptyClients = new CreateProjectRequest(
-                "테스트 프로젝트",
-                "프로젝트 설명입니다",
-                100L,
-                Collections.emptyList(),
-                Arrays.asList(3L, 4L),
-                LocalDate.of(2025, 1, 1),
-                LocalDate.of(2025, 6, 30)
+        mockClientMembers = Arrays.asList(
+                ProjectClientMember.builder()
+                        .projectClientMemberId(1L)
+                        .userId(1L)
+                        .projectId(1L)
+                        .role(Role.READ)
+                        .assignedAt(LocalDate.now())
+                        .build(),
+                ProjectClientMember.builder()
+                        .projectClientMemberId(2L)
+                        .userId(2L)
+                        .projectId(1L)
+                        .role(Role.READ)
+                        .assignedAt(LocalDate.now())
+                        .build()
         );
 
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        when(projectService.saveProjectClientMember(anyList())).thenReturn(Collections.emptyList());
-        when(projectService.saveProjectDevMember(anyList())).thenReturn(Arrays.asList(mockDevMember));
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
-
-        ProjectResponse result = createProjectService.createProject(requestWithEmptyClients);
-
-        assertThat(result).isNotNull();
-        verify(projectService).saveProjectClientMember(argThat(List::isEmpty));
-        verify(historyRecorder, never()).recordHistory(eq(HistoryType.PROJECT_CLIENT_MEMBER), anyLong(), eq(ActionType.CREATE), any());
+        mockDevMembers = Arrays.asList(
+                ProjectDevMember.builder()
+                        .projectMemberId(10L)
+                        .userId(10L)
+                        .projectId(1L)
+                        .devPart(DevPart.BE)
+                        .assignedAt(LocalDate.now())
+                        .build(),
+                ProjectDevMember.builder()
+                        .projectMemberId(20L)
+                        .userId(20L)
+                        .projectId(1L)
+                        .devPart(DevPart.BE)
+                        .assignedAt(LocalDate.now())
+                        .build()
+        );
     }
 
     @Test
-    @DisplayName("빈 개발 멤버 리스트로 프로젝트 생성 시 빈 리스트가 저장된다.")
-    void givenEmptyDevMemberList_whenCreateProject_thenSaveEmptyList() {
-        CreateProjectRequest requestWithEmptyDevs = new CreateProjectRequest(
-                "테스트 프로젝트",
-                "프로젝트 설명입니다",
-                100L,
-                Arrays.asList(1L, 2L),
-                Collections.emptyList(),
-                LocalDate.of(2025, 1, 1),
-                LocalDate.of(2025, 6, 30)
+    @DisplayName("프로젝트를 생성하면 프로젝트와 멤버가 저장되고 히스토리가 기록된다")
+    void givenCreateProjectRequest_whenCreateProject_thenSaveProjectAndMembersAndRecordHistory() {
+        // given
+        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
+        when(projectService.saveClientMembers(anyList(), anyLong())).thenReturn(mockClientMembers);
+        when(projectService.saveDevMembers(anyList(), anyLong())).thenReturn(mockDevMembers);
+
+        // when
+        ProjectResponse response = createProjectService.createProject(request);
+
+        // then
+        // 1. 프로젝트가 저장되었는지 확인
+        verify(projectService).saveProject(any(Project.class));
+
+        // 2. 프로젝트 히스토리가 기록되었는지 확인
+        verify(historyRecorder).recordHistory(
+                eq(HistoryType.PROJECT),
+                eq(1L),
+                eq(ActionType.CREATE),
+                any(ProjectHistorySnapshot.class)
         );
 
-        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        when(projectService.saveProjectClientMember(anyList())).thenReturn(Arrays.asList(mockClientMember));
-        when(projectService.saveProjectDevMember(anyList())).thenReturn(Collections.emptyList());
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
+        // 3. 클라이언트 멤버가 저장되었는지 확인
+        verify(projectService).saveClientMembers(eq(Arrays.asList(1L, 2L)), eq(1L));
 
-        ProjectResponse result = createProjectService.createProject(requestWithEmptyDevs);
+        // 4. 클라이언트 멤버 히스토리가 기록되었는지 확인 (2개)
+        verify(historyRecorder, times(2)).recordHistory(
+                eq(HistoryType.PROJECT_CLIENT_MEMBER),
+                anyLong(),
+                eq(ActionType.CREATE),
+                any(ProjectClientMember.class)
+        );
 
-        assertThat(result).isNotNull();
-        verify(projectService).saveProjectDevMember(argThat(List::isEmpty));
-        verify(historyRecorder, never()).recordHistory(eq(HistoryType.PROJECT_DEV_MEMBER), anyLong(), eq(ActionType.CREATE), any());
+        // 5. 개발자 멤버가 저장되었는지 확인
+        verify(projectService).saveDevMembers(eq(Arrays.asList(10L, 20L)), eq(1L));
+
+        // 6. 개발자 멤버 히스토리가 기록되었는지 확인 (2개)
+        verify(historyRecorder, times(2)).recordHistory(
+                eq(HistoryType.PROJECT_DEV_MEMBER),
+                anyLong(),
+                eq(ActionType.CREATE),
+                any(ProjectDevMember.class)
+        );
+
+        // 7. 응답 검증
+        assertThat(response).isNotNull();
+        assertThat(response.projectId()).isEqualTo(1L);
+        assertThat(response.projectTitle()).isEqualTo("신규 프로젝트");
     }
 
     @Test
-    @DisplayName("프로젝트 생성 시 모든 저장 메서드가 순차적으로 호출된다.")
-    void givenCreateProjectRequest_whenCreateProject_thenAllSaveMethodsCalledInOrder() {
+    @DisplayName("프로젝트 생성 시 실행 순서가 올바르게 동작한다")
+    void givenCreateProjectRequest_whenCreateProject_thenExecuteInCorrectOrder() {
+        // given
         when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
-        when(projectService.saveProjectClientMember(anyList())).thenReturn(Arrays.asList(mockClientMember));
-        when(projectService.saveProjectDevMember(anyList())).thenReturn(Arrays.asList(mockDevMember));
-        lenient().doNothing().when(historyRecorder).recordHistory(any(HistoryType.class), anyLong(), any(ActionType.class), any(Object.class));
+        when(projectService.saveClientMembers(anyList(), anyLong())).thenReturn(mockClientMembers);
+        when(projectService.saveDevMembers(anyList(), anyLong())).thenReturn(mockDevMembers);
 
-        createProjectService.createProject(mockRequest);
+        // when
+        createProjectService.createProject(request);
 
+        // then - 순서 검증 (InOrder 사용)
         var inOrder = inOrder(projectService, historyRecorder);
+
+        // 1. 프로젝트 저장
         inOrder.verify(projectService).saveProject(any(Project.class));
-        inOrder.verify(historyRecorder).recordHistory(eq(HistoryType.PROJECT), anyLong(), eq(ActionType.CREATE), any(ProjectHistorySnapshot.class));
-        inOrder.verify(projectService).saveProjectClientMember(anyList());
-        inOrder.verify(historyRecorder).recordHistory(eq(HistoryType.PROJECT_CLIENT_MEMBER), anyLong(), eq(ActionType.CREATE), any(ProjectClientMember.class));
-        inOrder.verify(projectService).saveProjectDevMember(anyList());
-        inOrder.verify(historyRecorder).recordHistory(eq(HistoryType.PROJECT_DEV_MEMBER), anyLong(), eq(ActionType.CREATE), any(ProjectDevMember.class));
+
+        // 2. 프로젝트 히스토리 기록
+        inOrder.verify(historyRecorder).recordHistory(
+                eq(HistoryType.PROJECT),
+                eq(1L),
+                eq(ActionType.CREATE),
+                any(ProjectHistorySnapshot.class)
+        );
+
+        // 3. 클라이언트 멤버 저장
+        inOrder.verify(projectService).saveClientMembers(anyList(), anyLong());
+
+        // 4. 개발자 멤버 저장
+        inOrder.verify(projectService).saveDevMembers(anyList(), anyLong());
+    }
+
+    @Test
+    @DisplayName("빈 멤버 리스트로 프로젝트를 생성해도 정상 동작한다")
+    void givenEmptyMemberList_whenCreateProject_thenSaveProjectWithoutMembers() {
+        // given
+        CreateProjectRequest emptyMemberRequest = new CreateProjectRequest(
+                "신규 프로젝트",
+                "프로젝트 설명",
+                100L,
+                List.of(),  // 빈 클라이언트 멤버
+                List.of(),  // 빈 개발자 멤버
+                LocalDate.now(),
+                LocalDate.now().plusMonths(6)
+        );
+
+        when(projectService.saveProject(any(Project.class))).thenReturn(mockProject);
+        when(projectService.saveClientMembers(anyList(), anyLong())).thenReturn(List.of());
+        when(projectService.saveDevMembers(anyList(), anyLong())).thenReturn(List.of());
+
+        // when
+        ProjectResponse response = createProjectService.createProject(emptyMemberRequest);
+
+        // then
+        // 1. 프로젝트는 저장됨
+        verify(projectService).saveProject(any(Project.class));
+
+        // 2. 멤버 저장은 호출되지만 빈 리스트
+        verify(projectService).saveClientMembers(eq(List.of()), eq(1L));
+        verify(projectService).saveDevMembers(eq(List.of()), eq(1L));
+
+        // 3. 멤버 히스토리는 기록되지 않음 (빈 리스트이므로)
+        verify(historyRecorder, never()).recordHistory(
+                eq(HistoryType.PROJECT_CLIENT_MEMBER),
+                anyLong(),
+                eq(ActionType.CREATE),
+                any()
+        );
+        verify(historyRecorder, never()).recordHistory(
+                eq(HistoryType.PROJECT_DEV_MEMBER),
+                anyLong(),
+                eq(ActionType.CREATE),
+                any()
+        );
+
+        // 4. 응답은 정상적으로 반환됨
+        assertThat(response).isNotNull();
     }
 }


### PR DESCRIPTION
## PR 요약 #4 
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항

프로젝트 수정 시, 구성원 변경에 대한 수정이 이루어 지지 않는 문제를 해결했습니다.
프로젝트 생성, 수정 시 구성원을 받는 필드 이름을 Id로 명확하게 변경하였습니다.

---

## 체크리스트

### 코드 품질
- [ ] 코드가 정상적으로 빌드됩니다.
- [ ] 로컬 테스트를 통과했습니다.
- [ ] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [ ] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [ ] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [ ] 예외 상황을 고려한 테스트를 진행했습니다.
- [ ] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [ ] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
