### PR TITLE
refactor : CS 게시글 리스트에 사용자 이름 반환하도록 수정

### DIFF
--- a/src/main/java/com/workhub/cs/dto/csPost/CsPostResponse.java
+++ b/src/main/java/com/workhub/cs/dto/csPost/CsPostResponse.java
@@ -15,12 +15,13 @@ public record CsPostResponse(
         String title,
         String content,
         Long userId,
+        String userName,
         List<CsPostFileResponse> files,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
 
-    public static CsPostResponse from(CsPost post, List<CsPostFile> fileList) {
+    public static CsPostResponse from(CsPost post, List<CsPostFile> fileList, String userName) {
 
         List<CsPostFileResponse> fileResponses =
                 (fileList == null) ? Collections.emptyList() :
@@ -34,19 +35,21 @@ public record CsPostResponse(
                 .title(post.getTitle())
                 .content(post.getContent())
                 .userId(post.getUserId())
+                .userName(userName)
                 .files(fileResponses)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
     }
 
-    public static CsPostResponse from(CsPost post) {
+    public static CsPostResponse from(CsPost post, String userName) {
         return CsPostResponse.builder()
                 .csPostId(post.getCsPostId())
                 .deletedAt(post.getDeletedAt())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .userId(post.getUserId())
+                .userName(userName)
                 .files(Collections.emptyList()) // 리스트 조회에서는 파일 불러오지 않음
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())

--- a/src/main/java/com/workhub/cs/port/AuthorLookupPort.java
+++ b/src/main/java/com/workhub/cs/port/AuthorLookupPort.java
@@ -1,0 +1,17 @@
+package com.workhub.cs.port;
+
+import com.workhub.cs.port.dto.AuthorProfile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * CS 모듈이 외부 사용자 정보를 조회하기 위한 포트.
+ */
+public interface AuthorLookupPort {
+
+    Optional<AuthorProfile> findByUserId(Long userId);
+
+    Map<Long, AuthorProfile> findByUserIds(List<Long> userIds);
+}

--- a/src/main/java/com/workhub/cs/port/dto/AuthorProfile.java
+++ b/src/main/java/com/workhub/cs/port/dto/AuthorProfile.java
@@ -1,0 +1,7 @@
+package com.workhub.cs.port.dto;
+
+public record AuthorProfile(
+        Long userId,
+        String userName
+) {
+}

--- a/src/main/java/com/workhub/cs/service/csPost/CreateCsPostService.java
+++ b/src/main/java/com/workhub/cs/service/csPost/CreateCsPostService.java
@@ -4,6 +4,8 @@ import com.workhub.cs.dto.csPost.CsPostRequest;
 import com.workhub.cs.dto.csPost.CsPostResponse;
 import com.workhub.cs.entity.CsPost;
 import com.workhub.cs.entity.CsPostFile;
+import com.workhub.cs.port.AuthorLookupPort;
+import com.workhub.cs.port.dto.AuthorProfile;
 import com.workhub.global.entity.ActionType;
 import com.workhub.project.service.ProjectService;
 import jakarta.transaction.Transactional;
@@ -20,6 +22,7 @@ public class CreateCsPostService {
     private final CsPostService csPostService;
     private final ProjectService projectService;
     private final CsPostNotificationService csPostNotificationService;
+    private final AuthorLookupPort authorLookupPort;
 
     /**
      * CS POST를 작성한다.
@@ -48,7 +51,11 @@ public class CreateCsPostService {
         csPostService.snapShotAndRecordHistory(csPost, csPost.getCsPostId(), ActionType.CREATE);
         csPostNotificationService.notifyCreated(projectId, csPost.getCsPostId(), csPost.getTitle());
 
-        return CsPostResponse.from(csPost, files);
+        String userName = authorLookupPort.findByUserId(userId)
+                .map(AuthorProfile::userName)
+                .orElse(null);
+
+        return CsPostResponse.from(csPost, files, userName);
     }
 
 }

--- a/src/main/java/com/workhub/cs/service/csPost/UpdateCsPostService.java
+++ b/src/main/java/com/workhub/cs/service/csPost/UpdateCsPostService.java
@@ -7,6 +7,8 @@ import com.workhub.cs.entity.CsPost;
 import com.workhub.cs.entity.CsPostFile;
 import com.workhub.cs.entity.CsPostStatus;
 import com.workhub.cs.entity.CsQna;
+import com.workhub.cs.port.AuthorLookupPort;
+import com.workhub.cs.port.dto.AuthorProfile;
 import com.workhub.cs.service.CsPostAccessValidator;
 import com.workhub.cs.service.csQna.CsQnaService;
 import com.workhub.global.entity.ActionType;
@@ -28,6 +30,7 @@ public class UpdateCsPostService {
     private final CsPostAccessValidator csPostAccessValidator;
     private final CsPostNotificationService csPostNotificationService;
     private final CsQnaService csQnaService;
+    private final AuthorLookupPort authorLookupPort;
 
     /**
      * CS POST를 수정한다.
@@ -57,7 +60,11 @@ public class UpdateCsPostService {
                 .collect(Collectors.toSet());
         csPostNotificationService.notifyUpdated(projectId, csPostId, csPost.getTitle(), commenters);
 
-        return CsPostResponse.from(csPost, visibleFiles);
+        String userName = authorLookupPort.findByUserId(csPost.getUserId())
+                .map(AuthorProfile::userName)
+                .orElse(null);
+
+        return CsPostResponse.from(csPost, visibleFiles, userName);
     }
 
     /**

--- a/src/main/java/com/workhub/userTable/service/UserAuthorLookupAdapter.java
+++ b/src/main/java/com/workhub/userTable/service/UserAuthorLookupAdapter.java
@@ -1,0 +1,46 @@
+package com.workhub.userTable.service;
+
+import com.workhub.cs.port.AuthorLookupPort;
+import com.workhub.cs.port.dto.AuthorProfile;
+import com.workhub.userTable.entity.UserTable;
+import com.workhub.userTable.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class UserAuthorLookupAdapter implements AuthorLookupPort {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Optional<AuthorProfile> findByUserId(Long userId) {
+        if (userId == null) {
+            return Optional.empty();
+        }
+
+        return userRepository.findById(userId)
+                .map(this::toProfile);
+    }
+
+    @Override
+    public Map<Long, AuthorProfile> findByUserIds(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, UserTable> users = userRepository.findMapByUserIdIn(userIds);
+
+        return users.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> toProfile(entry.getValue())));
+    }
+
+    private AuthorProfile toProfile(UserTable user) {
+        return new AuthorProfile(user.getUserId(), user.getUserName());
+    }
+}

--- a/src/test/java/com/workhub/cs/service/csPost/CreateCsPostServiceTest.java
+++ b/src/test/java/com/workhub/cs/service/csPost/CreateCsPostServiceTest.java
@@ -4,6 +4,8 @@ import com.workhub.cs.dto.csPost.CsPostFileRequest;
 import com.workhub.cs.dto.csPost.CsPostRequest;
 import com.workhub.cs.dto.csPost.CsPostResponse;
 import com.workhub.cs.entity.CsPost;
+import com.workhub.cs.port.AuthorLookupPort;
+import com.workhub.cs.port.dto.AuthorProfile;
 import com.workhub.global.error.ErrorCode;
 import com.workhub.global.error.exception.BusinessException;
 import com.workhub.project.entity.Project;
@@ -19,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,6 +40,9 @@ class CreateCsPostServiceTest {
 
     @Mock
     private CsPostNotificationService csPostNotificationService;
+
+    @Mock
+    private AuthorLookupPort authorLookupPort;
 
     @InjectMocks
     private CreateCsPostService createCsPostService;
@@ -63,12 +69,14 @@ class CreateCsPostServiceTest {
 
         when(projectService.validateCompletedProject(projectId)).thenReturn(Project.builder().projectId(projectId).projectTitle("p").status(Status.COMPLETED).build());
         when(csPostService.save(any(CsPost.class))).thenReturn(mockSaved);
+        when(authorLookupPort.findByUserId(userId)).thenReturn(Optional.of(new AuthorProfile(userId, "작성자")));
 
         CsPostResponse result = createCsPostService.create(projectId, userId, request);
 
         assertThat(result.csPostId()).isEqualTo(1L);
         assertThat(result.title()).isEqualTo("문의 제목");
         assertThat(result.content()).isEqualTo("문의 내용");
+        assertThat(result.userName()).isEqualTo("작성자");
 
         verify(projectService).validateCompletedProject(projectId);
         verify(csPostService).save(any(CsPost.class));
@@ -91,6 +99,7 @@ class CreateCsPostServiceTest {
         when(projectService.validateCompletedProject(projectId)).thenReturn(Project.builder().projectId(projectId).projectTitle("p").status(Status.COMPLETED).build());
         when(csPostService.save(any(CsPost.class))).thenReturn(mockSaved);
         when(csPostService.saveAllFiles(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(authorLookupPort.findByUserId(userId)).thenReturn(Optional.of(new AuthorProfile(userId, "작성자")));
 
         createCsPostService.create(projectId, userId, request);
 
@@ -108,6 +117,7 @@ class CreateCsPostServiceTest {
         CsPostRequest request = new CsPostRequest("문의 제목", "문의 내용", null);
         when(projectService.validateCompletedProject(projectId)).thenReturn(Project.builder().projectId(projectId).projectTitle("p").status(Status.COMPLETED).build());
         when(csPostService.save(any(CsPost.class))).thenReturn(mockSaved);
+        when(authorLookupPort.findByUserId(userId)).thenReturn(Optional.of(new AuthorProfile(userId, "작성자")));
 
         createCsPostService.create(projectId, userId, request);
 

--- a/src/test/java/com/workhub/cs/service/csPost/UpdateCsPostServiceTest.java
+++ b/src/test/java/com/workhub/cs/service/csPost/UpdateCsPostServiceTest.java
@@ -4,6 +4,8 @@ import com.workhub.cs.dto.csPost.CsPostResponse;
 import com.workhub.cs.dto.csPost.CsPostUpdateRequest;
 import com.workhub.cs.entity.CsPost;
 import com.workhub.cs.entity.CsPostStatus;
+import com.workhub.cs.port.AuthorLookupPort;
+import com.workhub.cs.port.dto.AuthorProfile;
 import com.workhub.cs.service.CsPostAccessValidator;
 import com.workhub.cs.service.csQna.CsQnaService;
 import com.workhub.global.error.ErrorCode;
@@ -20,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -43,6 +46,9 @@ class UpdateCsPostServiceTest {
 
     @Mock
     private CsQnaService csQnaService;
+
+    @Mock
+    private AuthorLookupPort authorLookupPort;
 
     @InjectMocks
     private UpdateCsPostService updateCsPostService;
@@ -87,11 +93,13 @@ class UpdateCsPostServiceTest {
 
         when(csPostService.findFilesByCsPostId(csPostId))
                 .thenReturn(List.of());
+        when(authorLookupPort.findByUserId(userId)).thenReturn(Optional.of(new AuthorProfile(userId, "작성자")));
 
         CsPostResponse result = updateCsPostService.update(projectId, csPostId, userId, request);
 
         assertThat(result.title()).isEqualTo("수정 제목");
         assertThat(result.content()).isEqualTo("수정 완료");
+        assertThat(result.userName()).isEqualTo("작성자");
 
         assertThat(original.getTitle()).isEqualTo("수정 제목");
         assertThat(original.getContent()).isEqualTo("수정 완료");


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
 - src/main/java/com/workhub/cs/port/AuthorLookupPort.java: CS 모듈이 외부 사용자 정보 획득 방법을 직접 알 필요가 없도록, 작성자 이름 조회를 추상화한 포트를 정의했습니다. 이를 통해 CS 도메인은 더 이상 UserService나 UserRepository 구현에 의존하지 않습니다.
  - src/main/java/com/workhub/cs/port/dto/AuthorProfile.java: 포트에서 주고받는 작성자 정보를 표현하는 DTO를 추가했습니다. 필요한 최소 정보(userId, userName)만 노출하여 도메인 간 계약을 단순화했습니다.
  - src/main/java/com/workhub/userTable/service/UserAuthorLookupAdapter.java: user 모듈 내부에서 포트를 구현한 어댑터로, 기존 UserRepository를 활용해 단건/다건 작성자 정보를 조회합니다. 이렇게 구성하면 CS 쪽은 여전히 추상 포트만 의존하고, 실제 구현은 user 모듈에서 관리할 수 있습니다.
  - src/main/java/com/workhub/cs/service/csPost/CreateCsPostService.java, ReadCsPostService.java, UpdateCsPostService.java: 모든 CRUD 서비스가 새 포트를 주입받아 작성자 이름을 조회하도록 수정했습니다. 단건 조회/수정에서는 findByUserId를, 목록 조회에서는 findByUserIds 결과 맵을 사용해 각 게시글의 작성자명을 채웁니다. 이로써 기존
    “CS→User” 직접 의존을 “CS→포트(추상화)”로 교체했습니다.
  - src/test/java/com/workhub/cs/service/csPost/*.java: 위 서비스들을 검증하는 단위 테스트에서 AuthorLookupPort 모킹과 기대값을 갱신했습니다. 사용자 이름이 포트 결과로 채워지는지 확인하도록 assertion을 조정했습니다.

  이런 방식으로 구현한 이유는, 프로젝트 기존 설계가 CS CRUD 서비스와 CsPostService 간 결합을 최소화하도록 되어 있어 user 모듈 직접 의존을 피해야 했기 때문입니다.


---

## 체크리스트

### 코드 품질
- [x] 코드가 정상적으로 빌드됩니다.
- [x] 로컬 테스트를 통과했습니다.
- [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [x] 예외 상황을 고려한 테스트를 진행했습니다.
- [x] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [ ] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
