### PR TITLE
fix : 프로젝트 CS POST 리스트 조회시 전체 프로젝트 게시물 조회 오류 수정

### DIFF
--- a/src/main/java/com/workhub/cs/repository/csPost/CsPostRepositoryCustom.java
+++ b/src/main/java/com/workhub/cs/repository/csPost/CsPostRepositoryCustom.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface CsPostRepositoryCustom {
 
-    Page<CsPost> findCsPosts(CsPostSearchRequest searchType, Pageable pageable);
+    Page<CsPost> findCsPosts(Long projectId, CsPostSearchRequest searchType, Pageable pageable);
 }

--- a/src/main/java/com/workhub/cs/repository/csPost/CsPostRepositoryImpl.java
+++ b/src/main/java/com/workhub/cs/repository/csPost/CsPostRepositoryImpl.java
@@ -19,13 +19,14 @@ public class CsPostRepositoryImpl implements CsPostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<CsPost> findCsPosts(CsPostSearchRequest searchRequest, Pageable pageable) {
+    public Page<CsPost> findCsPosts(Long projectId, CsPostSearchRequest searchRequest, Pageable pageable) {
 
         QCsPost csPost = QCsPost.csPost;
 
         List<CsPost> result =  queryFactory
                 .selectFrom(csPost)
                 .where(
+                        projectEq(projectId),
                         csPost.deletedAt.isNull(),
                         valueContains(searchRequest.searchValue()),
                         statusEq(searchRequest.csPostStatus())
@@ -39,6 +40,7 @@ public class CsPostRepositoryImpl implements CsPostRepositoryCustom {
                 .select(csPost.count())
                 .from(csPost)
                 .where(
+                        projectEq(projectId),
                         csPost.deletedAt.isNull(),
                         valueContains(searchRequest.searchValue()),
                         statusEq(searchRequest.csPostStatus())
@@ -46,6 +48,10 @@ public class CsPostRepositoryImpl implements CsPostRepositoryCustom {
                 .fetchOne();
 
         return new PageImpl<>(result, pageable, total == null ? 0 : total);
+    }
+
+    private BooleanExpression projectEq(Long projectId) {
+        return projectId == null ? null : QCsPost.csPost.projectId.eq(projectId);
     }
 
     private BooleanExpression valueContains(String value) {

--- a/src/main/java/com/workhub/cs/service/csPost/CsPostService.java
+++ b/src/main/java/com/workhub/cs/service/csPost/CsPostService.java
@@ -64,8 +64,8 @@ public class CsPostService {
         return csPostFileRepository.findByCsPostId(csPostId);
     }
 
-    public Page<CsPost> findCsPosts(CsPostSearchRequest searchType, Pageable pageable) {
-        return csPostRepository.findCsPosts(searchType, pageable);
+    public Page<CsPost> findCsPosts(Long projectId, CsPostSearchRequest searchType, Pageable pageable) {
+        return csPostRepository.findCsPosts(projectId, searchType, pageable);
     }
 
     /**

--- a/src/main/java/com/workhub/cs/service/csPost/ReadCsPostService.java
+++ b/src/main/java/com/workhub/cs/service/csPost/ReadCsPostService.java
@@ -64,7 +64,7 @@ public class ReadCsPostService {
     public Page<CsPostResponse> findCsPosts(Long projectId, CsPostSearchRequest searchType, Pageable pageable) {
 
         projectService.validateCompletedProject(projectId);
-        Page<CsPost> csPosts = csPostService.findCsPosts(searchType, pageable);
+        Page<CsPost> csPosts = csPostService.findCsPosts(projectId, searchType, pageable);
 
         Map<Long, AuthorProfile> authorMap = loadAuthors(csPosts);
 

--- a/src/test/java/com/workhub/cs/service/csPost/ReadCsPostServiceTest.java
+++ b/src/test/java/com/workhub/cs/service/csPost/ReadCsPostServiceTest.java
@@ -138,7 +138,7 @@ class ReadCsPostServiceTest {
                         .status(Status.COMPLETED)
                         .build()
         );
-        when(csPostService.findCsPosts(request, pageable)).thenReturn(mockPage);
+        when(csPostService.findCsPosts(projectId, request, pageable)).thenReturn(mockPage);
         when(authorLookupPort.findByUserIds(anyList())).thenReturn(
                 Map.of(
                         1L, new AuthorProfile(1L, "작성자1"),
@@ -151,7 +151,7 @@ class ReadCsPostServiceTest {
 
         // then
         verify(projectService).validateCompletedProject(projectId);
-        verify(csPostService).findCsPosts(request, pageable);
+        verify(csPostService).findCsPosts(projectId, request, pageable);
 
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(2);


### PR DESCRIPTION
## PR 요약
> 이 PR이 어떤 변경을 하는지 간단히 설명하고, 체크 표시는 괄호 사이에 소문자 'x'를 삽입하세요.

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

## 주요 변경 사항
CsPost 리스트 불러올 때, 프로젝트 아이디로 게시글을 가져오지 않아서 전체 프로젝트에서 전체 게시물에 나오고 있던 오류를 발견하여 수정

---

## 체크리스트

### 코드 품질
- [x] 코드가 정상적으로 빌드됩니다.
- [x] 로컬 테스트를 통과했습니다.
- [x] 불필요한 콘솔 출력, 주석을 제거했습니다.
- [x] 네이밍 및 포맷팅 규칙을 준수했습니다.

### 기능 검증
- [x] 주요 기능(화면, API, 로직)이 정상 동작합니다.
- [x] 예외 상황을 고려한 테스트를 진행했습니다.
- [x] UI/UX 변경 시 디자인 가이드에 맞게 적용했습니다.

### 문서 및 이슈 연동
- [ ] 관련 이슈 번호를 연결했습니다. (예: `Closes #123`)
- [ ] 변경된 부분을 `README` 또는 문서에 반영했습니다.

---

## 참고 사항
> 리뷰어가 알아야 할 추가 정보, 테스트 방법 등을 작성해주세요.

예:  
- 테스트 계정 정보  
- 관련 API 엔드포인트  
- 로컬 테스트 방법  

---

## 리뷰어 체크리스트
- [ ] 코드 로직이 명확하고, 부작용(side-effect)이 없습니다.
- [ ] 테스트 커버리지가 충분합니다.
- [ ] PR 제목과 내용이 일관됩니다.
- [ ] 커밋 메시지가 명확합니다.
